### PR TITLE
Add Existence Checks to Classes & Methods in External Refinements

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/ErrorExtRefNonExistentClass.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorExtRefNonExistentClass.java
@@ -1,0 +1,8 @@
+package testSuite;
+
+import liquidjava.specification.ExternalRefinementsFor;
+
+@ExternalRefinementsFor("non.existent.Class")
+public interface ErrorExtRefNonExistentClass {
+    public void NonExistentClass(); 
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorExtRefNonExistentMethod.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorExtRefNonExistentMethod.java
@@ -1,0 +1,16 @@
+package testSuite;
+
+import liquidjava.specification.ExternalRefinementsFor;
+import liquidjava.specification.RefinementPredicate;
+import liquidjava.specification.StateRefinement;
+
+@ExternalRefinementsFor("java.util.ArrayList")
+public interface ErrorExtRefNonExistentMethod<E> {
+
+    @RefinementPredicate("int size(ArrayList l)")
+    @StateRefinement(to = "size(this) == 0")
+    public void ArrayList();
+
+    @StateRefinement(to = "size(this) == (size(old(this)) + 1)")
+    public void adddd(E e);
+}

--- a/liquidjava-example/src/main/java/testSuite/math/correctInvocation/MathRefinements.java
+++ b/liquidjava-example/src/main/java/testSuite/math/correctInvocation/MathRefinements.java
@@ -57,9 +57,6 @@ public interface MathRefinements {
     @Refinement("(a > b)? (_ == b):(_ == a)")
     public int min(int a, int b);
 
-    @Refinement(" _ > 0.0 && _ < 1.0")
-    public long random(long a, long b);
-
     @Refinement("((sig > 0)?(_ > 0):(_ < 0)) && (( _ == arg)||(_ == -arg))")
     public float copySign(float arg, float sig);
 }


### PR DESCRIPTION
Added validation to ensure that classes and methods in external refinements actually exist. Also added a test for each case.
For now we'll just return an error, but in the future we'll turn these into warnings (because of dynamic generated classes).

```java
@ExternalRefinementsFor("non.existent.Class")
public interface ErrorExtRefNonExistentClass {
    public void NonExistentClass(); 
}
```
> Found Error: Could not find class 'non.existent.Class'

```java
@ExternalRefinementsFor("java.util.ArrayList")
public interface ErrorExtRefNonExistentMethod<E> {

    // ...

    @StateRefinement(to = "size(this) == (size(old(this)) + 1)")
    public void adddd(E e);
}
```
> Found Error: Could not find method 'adddd(java.lang.Object)' in class 'java.util.ArrayList'
