### PR TITLE
Fix Refined Method Overloading

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/classes/method_overload_error/DummySemaphoreRefinements.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/method_overload_error/DummySemaphoreRefinements.java
@@ -1,0 +1,12 @@
+package testSuite.classes.method_overload_error;
+
+import liquidjava.specification.ExternalRefinementsFor;
+import liquidjava.specification.Refinement;
+
+@ExternalRefinementsFor("java.util.concurrent.Semaphore")
+public interface DummySemaphoreRefinements {
+
+	public abstract void acquire();
+
+	public abstract void acquire(@Refinement("_ >= 0") int permits) throws InterruptedException;
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/method_overload_error/TestMethodOverloadEror.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/method_overload_error/TestMethodOverloadEror.java
@@ -1,0 +1,10 @@
+package testSuite.classes.method_overload_error;
+
+import java.util.concurrent.Semaphore;
+
+public class TestMethodOverloadEror {
+	public static void main(String[] args) throws InterruptedException {
+		Semaphore sem = new Semaphore(1);
+		sem.acquire(-1);
+	}
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/RefinedFunction.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/RefinedFunction.java
@@ -12,6 +12,7 @@ public class RefinedFunction extends Refined {
     private List<Variable> argRefinements;
     private String targetClass;
     private List<ObjectState> stateChange;
+    private String signature;
 
     public RefinedFunction() {
         argRefinements = new ArrayList<>();
@@ -45,6 +46,14 @@ public class RefinedFunction extends Refined {
 
     public String getTargetClass() {
         return targetClass;
+    }
+
+    public void setSignature(String signature) {
+        this.signature = signature;
+    }
+
+    public String getSignature() {
+        return signature;
     }
 
     public Predicate getRenamedRefinements(Context c, CtElement element) {
@@ -132,8 +141,8 @@ public class RefinedFunction extends Refined {
 
     @Override
     public String toString() {
-        return "Function [name=" + super.getName() + ", argRefinements=" + argRefinements + ", refReturn="
-                + super.getRefinement() + ", targetClass=" + targetClass + "]";
+        return "Function [name=" + super.getName() + ", signature=" + signature + ", argRefinements=" + argRefinements
+                + ", refReturn=" + super.getRefinement() + ", targetClass=" + targetClass + "]";
     }
 
     @Override
@@ -142,6 +151,7 @@ public class RefinedFunction extends Refined {
         int result = super.hashCode();
         result = prime * result + ((argRefinements == null) ? 0 : argRefinements.hashCode());
         result = prime * result + ((targetClass == null) ? 0 : targetClass.hashCode());
+        result = prime * result + ((signature == null) ? 0 : signature.hashCode());
         return result;
     }
 
@@ -157,12 +167,17 @@ public class RefinedFunction extends Refined {
         if (argRefinements == null) {
             if (other.argRefinements != null)
                 return false;
-        } else if (argRefinements.size() != other.argRefinements.size())
+        } else if (!argRefinements.equals(other.argRefinements))
             return false;
         if (targetClass == null) {
             if (other.targetClass != null)
                 return false;
         } else if (!targetClass.equals(other.targetClass))
+            return false;
+        if (signature == null) {
+            if (other.signature != null)
+                return false;
+        } else if (!signature.equals(other.signature))
             return false;
         return true;
     }


### PR DESCRIPTION
There was still an issue regarding refinements in overloaded methods, where the typechecker mistakenly looked up the wrong method. `RefinedFunction` now stores the fully qualified method signature and uses it in equality/hash logic in order to distinguish between overloaded methods in the context. Also added a test that previously passed and now successfully fails.