### PR TITLE
Skip String Literals in OperationsChecker

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/CorrectStringConcat.java
+++ b/liquidjava-example/src/main/java/testSuite/CorrectStringConcat.java
@@ -1,0 +1,8 @@
+package testSuite;
+
+public class CorrectStringConcat {
+
+    void example() {
+        System.out.println("Hello, " + "World!");
+    }
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/OperationsChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/OperationsChecker.java
@@ -87,6 +87,8 @@ public class OperationsChecker {
                 operator.putMetadata(rtc.REFINE_KEY, Predicate.createEquals(Predicate.createVar(rtc.WILD_VAR), oper));
         } else if (types.contains(type)) {
             operator.putMetadata(rtc.REFINE_KEY, Predicate.createEquals(Predicate.createVar(rtc.WILD_VAR), oper));
+        } else if (type.equals("java.lang.String")) {
+            // skip strings
         } else {
             throw new NotImplementedException("Literal type not implemented");
         }
@@ -238,6 +240,10 @@ public class OperationsChecker {
 
         } else if (element instanceof CtLiteral<?>) {
             CtLiteral<?> l = (CtLiteral<?>) element;
+            if (l.getType().getQualifiedName().equals("java.lang.String")) {
+                // skip strings
+                return new Predicate();
+            }
             return new Predicate(l.getValue().toString(), element, rtc.getErrorEmitter());
 
         } else if (element instanceof CtInvocation<?>) {


### PR DESCRIPTION
This PR is similar to #63.
There was a problem where this simple program failed parsing:

```java
public class Example {
    void example() {
        System.out.println("Hello, " + "World!");
    }
}
```

```
Syntax error with message
Found 1 error, with the message:
* Error in no viable alternative at input 'Hello,', in the position 5
```

This was because strings were not being handled in the binary operations, in this case string concatenation.
It was fixed by skipping string literals in the `OperationsChecker`.