### PR TITLE
Update groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Additionally, you'll need the following dependency, which includes the LiquidJav
 #### Maven
 ```xml
 <dependency>
-    <groupId>io.github.rcosta358</groupId>
+    <groupId>io.github.liquid-java</groupId>
     <artifactId>liquidjava-api</artifactId>
     <version>0.0.3</version>
 </dependency>
@@ -60,7 +60,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.github.rcosta358:liquidjava-api:0.0.3'
+    implementation 'io.github.liquid-java:liquidjava-api:0.0.3'
 }
 ```
 

--- a/liquidjava-api/pom.xml
+++ b/liquidjava-api/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.github.rcosta358</groupId>
+	<groupId>io.github.liquid-java</groupId>
 	<artifactId>liquidjava-api</artifactId>
 	<version>0.0.3</version>
 	<name>liquidjava-api</name>

--- a/liquidjava-api/release.sh
+++ b/liquidjava-api/release.sh
@@ -1,0 +1,1 @@
+mvn -Dgpg.skip=false -Dmaven.deploy.skip=false clean deploy

--- a/liquidjava-example/pom.xml
+++ b/liquidjava-example/pom.xml
@@ -48,7 +48,7 @@
 			<version>${version.memcompiler}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.github.rcosta358</groupId>
+			<groupId>io.github.liquid-java</groupId>
 			<artifactId>liquidjava-api</artifactId>
 			<version>0.0.3</version>
 		</dependency>

--- a/liquidjava-verifier/pom.xml
+++ b/liquidjava-verifier/pom.xml
@@ -172,7 +172,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.github.rcosta358</groupId>
+			<groupId>io.github.liquid-java</groupId>
 			<artifactId>liquidjava-api</artifactId>
 			<version>0.0.3</version>
 		</dependency>


### PR DESCRIPTION
With the new `liquid-java` namespace, we can use the new group id for the API jar.

```xml
<dependency>
	<groupId>io.github.liquid-java</groupId> <!-- instead of io.github.rcosta358 -->
	<artifactId>liquidjava-api</artifactId>
	<version>0.0.3</version>
</dependency>
```

Also added a release script for publishing a new version using `mvn deploy`.