### PR TITLE
Update Links and Maven Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This project contains the LiquidJava verifier and its API, as well as some examp
 
 You can find out more about LiquidJava in the following resources:
 
-* [LiquidJava Website](https://catarinagamboa.github.io/liquidjava.html)
+* [LiquidJava Website](https://liquid-java.github.io)
 * [VS Code Extension (Marketplace)](https://marketplace.visualstudio.com/items?itemName=AlcidesFonseca.liquid-java)
-* [VS Code Extension (Source Code)](https://github.com/CatarinaGamboa/vscode-liquidjava)
-* [LiquidJava Examples](https://github.com/CatarinaGamboa/liquidjava-examples)
-* [LiquidJava External Libraries Examples](https://github.com/CatarinaGamboa/liquid-java-external-libs)
-<!-- * [Formalization of LiquidJava](https://github.com/CatarinaGamboa/liquidjava-formalization) - not opensource yet -->
+* [VS Code Extension (Source Code)](https://github.com/liquid-java/vscode-liquidjava)
+* [LiquidJava Examples](https://github.com/liquid-java/liquidjava-examples)
+* [LiquidJava External Libraries Examples](https://github.com/liquid-java/liquid-java-external-libs)
+<!-- * [Formalization of LiquidJava](https://github.com/liquid-java/liquidjava-formalization) - not opensource yet -->
 
 ## Getting Started
 
@@ -66,7 +66,7 @@ dependencies {
 
 #### Setup
 
-1. Clone the repository: `git clone https://github.com/CatarinaGamboa/liquidjava.git`
+1. Clone the repository: `git clone https://github.com/liquid-java/liquidjava.git`
 2. Build the project `mvn clean install`
 3. Run tests to verify installation: `mvn test`
 4. If importing into an IDE, import the project as a Maven project using the root `pom.xml`

--- a/docs/design/evaluation_survey/README.md
+++ b/docs/design/evaluation_survey/README.md
@@ -1,1 +1,1 @@
-Find the examples described in the Study in https://github.com/CatarinaGamboa/liquidjava-examples
+Find the examples described in the Study in https://github.com/liquid-java/liquidjava-examples

--- a/liquidjava-api/pom.xml
+++ b/liquidjava-api/pom.xml
@@ -3,12 +3,18 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>liquidjava</groupId>
+		<artifactId>liquidjava-umbrella</artifactId>
+		<version>1.0</version>
+	</parent>
+
 	<groupId>io.github.liquid-java</groupId>
 	<artifactId>liquidjava-api</artifactId>
 	<version>0.0.3</version>
 	<name>liquidjava-api</name>
 	<description>LiquidJava API</description>
-	<url>https://github.com/CatarinaGamboa/liquidjava</url>
+	<url>https://github.com/liquid-java/liquidjava</url>
 	<packaging>jar</packaging>
 
 	<licenses>
@@ -33,6 +39,12 @@
 			<url>https://github.com/alcides</url>
 		</developer>
 		<developer>
+			<id>pcanelas</id>
+			<name>Paulo Canelas</name>
+			<email>pcanelas@users.noreply.github.com</email>
+			<url>https://github.com/pcanelas</url>
+		</developer>
+		<developer>
 			<id>rcosta358</id>
 			<name>Ricardo Costa</name>
 			<email>rcosta358@users.noreply.github.com</email>
@@ -41,9 +53,9 @@
 	</developers>
 
 	<scm>
-		<connection>scm:git:git://github.com/CatarinaGamboa/liquidjava.git</connection>
-		<developerConnection>scm:git:ssh://github.com:CatarinaGamboa/liquidjava.git</developerConnection>
-		<url>https://github.com/CatarinaGamboa/liquidjava/tree/main</url>
+		<connection>scm:git:git://github.com/liquid-java/liquidjava.git</connection>
+		<developerConnection>scm:git:ssh://github.com:liquid-java/liquidjava.git</developerConnection>
+		<url>https://github.com/liquid-java/liquidjava/tree/main</url>
 	</scm>
 
 	<build>

--- a/liquidjava-api/release.sh
+++ b/liquidjava-api/release.sh
@@ -1,1 +1,0 @@
-mvn -Dgpg.skip=false -Dmaven.deploy.skip=false clean deploy

--- a/liquidjava-example/test1.txt
+++ b/liquidjava-example/test1.txt
@@ -1,5 +1,0 @@
-akbadoasfnncnksa
-pspifdlnksac
-apsfdnlckx
-laigdknz.m,cxieakfsdmcx
-aipfsdlzkn.cmx

--- a/liquidjava-verifier/pom.xml
+++ b/liquidjava-verifier/pom.xml
@@ -9,12 +9,54 @@
 		<version>1.0</version>
 	</parent>
 
-	<groupId>liquidjava-verifier
-		</groupId>
+	<groupId>io.github.liquid-java</groupId>
 	<artifactId>liquidjava-verifier</artifactId>
-	<version>5.2-SNAPSHOT</version>
+	<version>0.0.1</version>
 	<name>liquidjava-verifier</name>
+	<description>LiquidJava Verifier</description>
+	<url>https://github.com/liquid-java/liquidjava</url>
 	<packaging>jar</packaging>
+
+	<licenses>
+		<license>
+			<name>MIT License</name>
+			<url>https://opensource.org/licenses/MIT</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<id>CatarinaGamboa</id>
+			<name>Catarina Gamboa</name>
+			<email>CatarinaGamboa@users.noreply.github.com</email>
+			<url>https://github.com/CatarinaGamboa</url>
+		</developer>
+		<developer>
+			<id>alcides</id>
+			<name>Alcides Fonseca</name>
+			<email>alcides@users.noreply.github.com</email>
+			<url>https://github.com/alcides</url>
+		</developer>
+		<developer>
+			<id>pcanelas</id>
+			<name>Paulo Canelas</name>
+			<email>pcanelas@users.noreply.github.com</email>
+			<url>https://github.com/pcanelas</url>
+		</developer>
+		<developer>
+			<id>rcosta358</id>
+			<name>Ricardo Costa</name>
+			<email>rcosta358@users.noreply.github.com</email>
+			<url>https://github.com/rcosta358</url>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git://github.com/liquid-java/liquidjava.git</connection>
+		<developerConnection>scm:git:ssh://github.com:liquid-java/liquidjava.git</developerConnection>
+		<url>https://github.com/liquid-java/liquidjava/tree/main</url>
+	</scm>
 
 	<build>
 		<finalName>${jar.finalName}</finalName>
@@ -95,11 +137,95 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- Generate source JAR -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.0</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<!-- Generate Javadoc JAR -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.6.0</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<doclint>none</doclint>
+					<source>20</source>
+				</configuration>
+			</plugin>
+			
+			<!-- GPG Signing -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<skip>${gpg.skip}</skip>
+				</configuration>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<!-- Skip default deploy -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>3.1.2</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			
+			<!-- Central Publishing Plugin -->
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<version>0.9.0</version>
+				<extensions>true</extensions>
+				<configuration>
+					<publishingServerId>central</publishingServerId>
+					<skipPublishing>${maven.deploy.skip}</skipPublishing>
+					<!-- <autoPublish>true</autoPublish> -->
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
+	<distributionManagement>
+		<repository>
+			<id>central</id>
+			<url>https://central.sonatype.com/api/v1/publisher</url>
+		</repository>
+	</distributionManagement>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<javaVersion>20</javaVersion>
 		<maven.compiler.source>20</maven.compiler.source>
 		<maven.compiler.target>20</maven.compiler.target>
 		<!-- versions -->
@@ -107,12 +233,13 @@
 		<version.memcompiler>1.3.0</version.memcompiler>
 		<version.spoon>10.4.2</version.spoon>
 		<version.z3>4.8.17</version.z3>
-		<version.liquidjava>1.0</version.liquidjava>
 		<!-- plugin versions -->
 		<pVersion.compiler>3.8.0</pVersion.compiler>
 		<pVersion.surefire>3.1.2</pVersion.surefire>
 		<!-- name of the generated plugin -->
 		<jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
+		<gpg.skip>true</gpg.skip>
+		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 
 	<repositories>

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <api|verifier>"
+    exit 1
+fi
+
+MODULE=$1
+
+if [ "$MODULE" != "api" ] && [ "$MODULE" != "verifier" ]; then
+    echo "Invalid module: $MODULE"
+    echo "Usage: $0 <api|verifier>"
+    exit 1
+fi
+
+MODULE_DIR="liquidjava-$MODULE"
+
+cd "$MODULE_DIR"
+mvn -Dgpg.skip=false -Dmaven.deploy.skip=false clean deploy
+cd ..


### PR DESCRIPTION
- Updated links
- Updated `pom.xml` of `liquidjava-verifier` to release verifier in Maven Central, to be used by the language server as a dependency

```xml
<dependency>
	<groupId>io.github.liquid-java</groupId>
	<artifactId>liquidjava-verifier</artifactId>
	<version>0.0.1</version>
</dependency>
```

- Added a release script for both `liquidjava-api` and `liquidjava-verifier`