### PR TITLE
Prevent Index Out-Of-Bounds in Function Call With Empty Args

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
@@ -165,11 +165,13 @@ public class CreateASTVisitor {
             String name = Utils.qualifyName(prefix, gc.ID().getText());
             List<Expression> args = getArgs(gc.args());
             if (args.isEmpty())
-                throw new ParsingException("Function call cannot have empty arguments");
+                throw new ParsingException("Ghost call cannot have empty arguments");
             return new FunctionInvocation(name, args);
         } else {
             AliasCallContext gc = rc.aliasCall();
             List<Expression> args = getArgs(gc.args());
+            if (args.isEmpty())
+                throw new ParsingException("Alias call cannot have empty arguments");
             return new AliasInvocation(gc.ID_UPPER().getText(), args);
         }
     }


### PR DESCRIPTION
This PR is related to #86. Instead of adding `this` as default argument when none are provided, we throw a `ParsingException` with the appropriate message instead of failing with index out-of-bounds later on.

Before:
```
Index 0 out of bounds for length 0
```

After:
```
Syntax error with message
Function call cannot have empty arguments
Found in refinement:
size() > 0
In:
@liquidjava.specification.StateRefinement(from = "size() > 0")
void testMethod() {
}
```