### PR TITLE
Use Annotation Position in `ExternalClassNotFoundWarning`

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
@@ -14,6 +14,8 @@ import liquidjava.processor.refinement_checker.general_checkers.MethodsFunctions
 import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.parsing.RefinementsParser;
 import liquidjava.utils.Utils;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -38,12 +40,14 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
 
     @Override
     public <T> void visitCtInterface(CtInterface<T> intrface) {
-        Optional<String> externalRefinements = getExternalRefinement(intrface);
-        if (externalRefinements.isPresent()) {
-            this.prefix = externalRefinements.get();
+        Optional<CtAnnotation<?>> externalRef = getExternalRefinement(intrface);
+        if (externalRef.isPresent()) {
+            @SuppressWarnings("unchecked")
+            CtLiteral<String> literal = (CtLiteral<String>) externalRef.get().getAllValues().get("value");
+            this.prefix = literal.getValue();
             if (!classExists(prefix)) {
                 String message = String.format("Could not find class '%s'", prefix);
-                diagnostics.add(new ExternalClassNotFoundWarning(intrface.getPosition(), message, prefix));
+                diagnostics.add(new ExternalClassNotFoundWarning(externalRef.get().getPosition(), message, prefix));
                 return;
             }
             getRefinementFromAnnotation(intrface);

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
@@ -238,16 +238,13 @@ public abstract class TypeChecker extends CtScanner {
         }
     }
 
-    Optional<String> getExternalRefinement(CtInterface<?> intrface) {
-        Optional<String> ref = Optional.empty();
+    Optional<CtAnnotation<?>> getExternalRefinement(CtInterface<?> intrface) {
         for (CtAnnotation<? extends Annotation> ann : intrface.getAnnotations())
             if (ann.getActualAnnotation().annotationType().getCanonicalName()
                     .contentEquals("liquidjava.specification.ExternalRefinementsFor")) {
-                @SuppressWarnings("unchecked")
-                CtLiteral<String> s = (CtLiteral<String>) ann.getAllValues().get("value");
-                ref = Optional.of(s.getValue());
+                return Optional.of(ann);
             }
-        return ref;
+        return Optional.empty();
     }
 
     public void checkVariableRefinements(Predicate refinementFound, String simpleName, CtTypeReference<?> type,


### PR DESCRIPTION
This PR fixes an issue where the whole class was being highlighted when an `ExternalClassNotFound` occurred.
This was fixed by using the annotation position instead of the element position.

### Before

<img width="649" height="364" alt="image" src="https://github.com/user-attachments/assets/499f1dd1-417c-48a2-aebb-af22f78f3f30" />

### After

<img width="394" height="121" alt="image" src="https://github.com/user-attachments/assets/e7320ec2-36f8-4f61-980a-f3846793b393" />
