### PR TITLE
Skip Duplicate Tests in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Build the project (compiles and packages the code)
       - name: Build the project
-        run: mvn -B clean install --file pom.xml --batch-mode --fail-fast -Dgpg.skip=true -Dmaven.deploy.skip=true
+        run: mvn -B clean install -DskipTests --file pom.xml --batch-mode --fail-fast -Dgpg.skip=true -Dmaven.deploy.skip=true
 
       # Run tests
       - name: Run tests


### PR DESCRIPTION
This PR updates the Maven workflow to skip the tests during the Maven build in CI, preventing tests from running twice and reducing the build time.