### PR TITLE
Fix Operator Precedence

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/CorrectOperatorPrecedence.java
+++ b/liquidjava-example/src/main/java/testSuite/CorrectOperatorPrecedence.java
@@ -1,0 +1,66 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class CorrectOperatorPrecedence {
+
+    @Refinement("_ == 1 + 2 * 0")
+    int multiplicationBeforeAddition() {
+        return 1;
+    }
+
+    @Refinement("_ == (1 + 2) * 0")
+    int groupedAdditionBeforeMultiplication() {
+        return 0;
+    }
+
+    @Refinement("_ == 10 - 3 - 1")
+    int subtractionAssociatesLeft() {
+        return 6;
+    }
+
+    @Refinement("_ == 10 - (3 - 1)")
+    int groupedSubtractionAssociatesRight() {
+        return 8;
+    }
+
+    @Refinement("_ == -2 + 3")
+    int unaryBeforeAddition() {
+        return 1;
+    }
+
+    @Refinement("_ == (true || false && false)")
+    boolean andBeforeOr() {
+        return true;
+    }
+
+    @Refinement("_ == (!false && false)")
+    boolean notBeforeAnd() {
+        return false;
+    }
+
+    @Refinement("_ == (false --> true && false)")
+    boolean andBeforeImplication() {
+        return true;
+    }
+
+    @Refinement("_ == (true || true --> false)")
+    boolean orBeforeImplication() {
+        return false;
+    }
+
+    @Refinement("_ == (false --> false && false)")
+    boolean anotherAndBeforeImplication() {
+        return true;
+    }
+
+    @Refinement("_ == (false --> true --> false)")
+    boolean implicationAssociatesRight() {
+        return true;
+    }
+
+    @Refinement("_ == (true ? false : true ? false : true)")
+    boolean ternaryAssociatesRight() {
+        return false;
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorExtraToken.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorExtraToken.java
@@ -1,0 +1,12 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+@SuppressWarnings("unused")
+public class ErrorExtraToken {
+    
+    void test() {
+        @Refinement("true false") // Syntax Error
+        int a = 1;
+    }
+}

--- a/liquidjava-verifier/src/main/antlr4/rj/grammar/RJ.g4
+++ b/liquidjava-verifier/src/main/antlr4/rj/grammar/RJ.g4
@@ -1,41 +1,31 @@
 grammar RJ;
 
 
-prog: start | ;
+prog: start EOF;
 start:
 		pred	#startPred
 	|	alias	#startAlias
 	|	ghost	#startGhost
 	;
 
+//----------------------- Predicates -----------------------
 
 pred:
-		'(' pred ')'				#predGroup
-	|	'!' pred					#predNegate
-	|	pred LOGOP pred 			#predLogic
-	|	pred '?' pred ':' pred		#ite
-	|	exp							#predExp
+		'-' pred					#opMinus
+	|	'!' pred					#opNot
+	|	'(' pred ')'				#predGroup
+	|	literalExpression			#opLiteral
+	|	pred MULOP pred				#opArith
+	|	pred ('+'|'-') pred			#opArith
+	|	pred BOOLOP pred			#expBool
+	|	pred '&&' pred 				#predLogic
+	|	pred '||' pred 				#predLogic
+	|	<assoc=right> pred '-->' pred #predLogic
+	|	<assoc=right> pred '?' pred ':' pred #ite
 	;
-
-exp:
-		'(' exp ')'					#expGroup
-	|	exp BOOLOP exp				#expBool
-	|	operand						#expOperand
-	;
-
-operand:
-		literalExpression			#opLiteral
-	|	operand ARITHOP	operand		#opArith
-	|	operand '-'	operand			#opSub
-	|	'-' operand					#opMinus
-	|	'!' operand					#opNot
-	|	'(' operand ')'				#opGroup
-	;
-
 
 literalExpression:
-		'(' literalExpression ')'	#litGroup
-	|	literal						#lit
+		literal						#lit
 	| 	ID 							#var
 	|	functionCall				#invocation
 	|	enumerate					#enum
@@ -93,9 +83,8 @@ type:
 	|	type '[]';
 
 
-LOGOP   : '&&'|'||'| '-->';
 BOOLOP	 : '=='|'!='|'>='|'>'|'<='|'<';
-ARITHOP : '+'|'*'|'/'|'%';//|'-';
+MULOP   : '*'|'/'|'%';
 
 BOOL    : 'true' | 'false';
 ID_UPPER: ([A-Z][a-zA-Z0-9]*);

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/parsing/RefinementsParser.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/parsing/RefinementsParser.java
@@ -71,7 +71,7 @@ public class RefinementsParser {
     private static Optional<String> getErrors(String toParse) {
         RJErrorListener err = new RJErrorListener();
         RJParser parser = createParser(toParse, err);
-        parser.start(); // all consumed
+        parser.prog(); // all consumed
         if (err.getErrors() > 0)
             return Optional.of(err.getMessages());
         return Optional.empty();

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
@@ -20,7 +20,6 @@ import liquidjava.rj_language.ast.LiteralString;
 import liquidjava.rj_language.ast.UnaryExpression;
 import liquidjava.rj_language.ast.Var;
 import liquidjava.utils.Utils;
-import liquidjava.utils.constants.Formats;
 import liquidjava.utils.constants.Keys;
 
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -30,29 +29,20 @@ import rj.grammar.RJParser.ArgsContext;
 import rj.grammar.RJParser.DotCallContext;
 import rj.grammar.RJParser.EnumContext;
 import rj.grammar.RJParser.ExpBoolContext;
-import rj.grammar.RJParser.ExpContext;
-import rj.grammar.RJParser.ExpGroupContext;
-import rj.grammar.RJParser.ExpOperandContext;
 import rj.grammar.RJParser.FunctionCallContext;
 import rj.grammar.RJParser.GhostCallContext;
 import rj.grammar.RJParser.InvocationContext;
 import rj.grammar.RJParser.IteContext;
 import rj.grammar.RJParser.LitContext;
-import rj.grammar.RJParser.LitGroupContext;
 import rj.grammar.RJParser.LiteralContext;
 import rj.grammar.RJParser.LiteralExpressionContext;
 import rj.grammar.RJParser.OpArithContext;
-import rj.grammar.RJParser.OpGroupContext;
 import rj.grammar.RJParser.OpLiteralContext;
 import rj.grammar.RJParser.OpMinusContext;
 import rj.grammar.RJParser.OpNotContext;
-import rj.grammar.RJParser.OpSubContext;
-import rj.grammar.RJParser.OperandContext;
 import rj.grammar.RJParser.PredContext;
-import rj.grammar.RJParser.PredExpContext;
 import rj.grammar.RJParser.PredGroupContext;
 import rj.grammar.RJParser.PredLogicContext;
-import rj.grammar.RJParser.PredNegateContext;
 import rj.grammar.RJParser.ProgContext;
 import rj.grammar.RJParser.StartContext;
 import rj.grammar.RJParser.StartPredContext;
@@ -79,10 +69,6 @@ public class CreateASTVisitor {
             return startCreate(rc);
         else if (rc instanceof PredContext)
             return predCreate(rc);
-        else if (rc instanceof ExpContext)
-            return expCreate(rc);
-        else if (rc instanceof OperandContext)
-            return operandCreate(rc);
         else if (rc instanceof LiteralExpressionContext)
             return literalExpressionCreate(rc);
         else if (rc instanceof DotCallContext)
@@ -111,53 +97,31 @@ public class CreateASTVisitor {
     private Expression predCreate(ParseTree rc) throws LJError {
         if (rc instanceof PredGroupContext)
             return new GroupExpression(create(((PredGroupContext) rc).pred()));
-        else if (rc instanceof PredNegateContext)
-            return new UnaryExpression("!", create(((PredNegateContext) rc).pred()));
+        else if (rc instanceof OpLiteralContext)
+            return create(((OpLiteralContext) rc).literalExpression());
+        else if (rc instanceof OpMinusContext)
+            return new UnaryExpression("-", create(((OpMinusContext) rc).pred()));
+        else if (rc instanceof OpNotContext)
+            return new UnaryExpression("!", create(((OpNotContext) rc).pred()));
+        else if (rc instanceof OpArithContext)
+            return new BinaryExpression(create(((OpArithContext) rc).pred(0)),
+                    ((OpArithContext) rc).getChild(1).getText(), create(((OpArithContext) rc).pred(1)));
+        else if (rc instanceof ExpBoolContext)
+            return new BinaryExpression(create(((ExpBoolContext) rc).pred(0)), ((ExpBoolContext) rc).BOOLOP().getText(),
+                    create(((ExpBoolContext) rc).pred(1)));
         else if (rc instanceof PredLogicContext)
             return new BinaryExpression(create(((PredLogicContext) rc).pred(0)),
-                    ((PredLogicContext) rc).LOGOP().getText(), create(((PredLogicContext) rc).pred(1)));
-        else if (rc instanceof IteContext)
+                    ((PredLogicContext) rc).getChild(1).getText(), create(((PredLogicContext) rc).pred(1)));
+        if (rc instanceof IteContext)
             return new Ite(create(((IteContext) rc).pred(0)), create(((IteContext) rc).pred(1)),
                     create(((IteContext) rc).pred(2)));
-        else
-            return create(((PredExpContext) rc).exp());
-    }
 
-    private Expression expCreate(ParseTree rc) throws LJError {
-        if (rc instanceof ExpGroupContext)
-            return new GroupExpression(create(((ExpGroupContext) rc).exp()));
-        else if (rc instanceof ExpBoolContext) {
-            return new BinaryExpression(create(((ExpBoolContext) rc).exp(0)), ((ExpBoolContext) rc).BOOLOP().getText(),
-                    create(((ExpBoolContext) rc).exp(1)));
-        } else {
-            ExpOperandContext eoc = (ExpOperandContext) rc;
-            return create(eoc.operand());
-        }
-    }
-
-    private Expression operandCreate(ParseTree rc) throws LJError {
-        if (rc instanceof OpLiteralContext)
-            return create(((OpLiteralContext) rc).literalExpression());
-        else if (rc instanceof OpArithContext)
-            return new BinaryExpression(create(((OpArithContext) rc).operand(0)),
-                    ((OpArithContext) rc).ARITHOP().getText(), create(((OpArithContext) rc).operand(1)));
-        else if (rc instanceof OpSubContext)
-            return new BinaryExpression(create(((OpSubContext) rc).operand(0)), "-",
-                    create(((OpSubContext) rc).operand(1)));
-        else if (rc instanceof OpMinusContext)
-            return new UnaryExpression("-", create(((OpMinusContext) rc).operand()));
-        else if (rc instanceof OpNotContext)
-            return new UnaryExpression("!", create(((OpNotContext) rc).operand()));
-        else if (rc instanceof OpGroupContext)
-            return new GroupExpression(create(((OpGroupContext) rc).operand()));
         assert false;
         return null;
     }
 
     private Expression literalExpressionCreate(ParseTree rc) throws LJError {
-        if (rc instanceof LitGroupContext)
-            return new GroupExpression(create(((LitGroupContext) rc).literalExpression()));
-        else if (rc instanceof LitContext)
+        if (rc instanceof LitContext)
             return create(((LitContext) rc).literal());
         else if (rc instanceof VarContext)
             return new Var(((VarContext) rc).ID().getText());


### PR DESCRIPTION
This PR fixes operator precedence in the LiquidJava refinements, where e.g. the operators `+` and `-` had the same precedence as `*`, `/`, and `%`. This could lead to unexpected bugs and forced users to explicitly group expressions in parentheses.

Also, the grammar rejected some valid nested boolean expressions, such as `"_ == (true || false && false)"`, because `&&` and `||` were not allowed in the `exp` rule.

Finally, the parser could accept only a valid prefix of the expression. For example, the refinement `true false` would be accepted as `true` instead of throwing a syntax error, silently ignoring `false`. 

### Changes

The grammar now defines expression parsing in a single left-recursive `pred` rule, making the precedence order explicit, with the last two being right associative:

`!` → `* / %` → `+ -` → `== != >= > <= <` → `&&` → `||` → `-->` → `? :`

To make sure the whole refinement string is consumed, `prog: start | ;` was changed to to `prog: start EOF;` and `parser.start()` to `parser.prog()`.

### Examples

```java
@Refinement("_ == 1 + 2 * 0")
int x = 1;
// Before: Refinement Error: #x⁰ == 1 is not a subtype of #x⁰ == 0
// After: No error
```

```java
@Refinement("_ == (true || false && false)")
// Before: Syntax Error
// After: No error
```

```java
@Refinement("true false")
// Before: No error
// After: Syntax Error
```

