### PR TITLE
Add Maven Central Publish Workflows

### DIFF
--- a/.github/workflows/publish-api.yml
+++ b/.github/workflows/publish-api.yml
@@ -1,0 +1,45 @@
+name: Publish API
+
+on:
+  push:
+    tags:
+      - "api-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish liquidjava-api to Maven Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag is on main
+        run: |
+          git fetch origin main
+          TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          git merge-base --is-ancestor "$TAG_COMMIT" origin/main
+
+      - name: Set up JDK 20
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "20"
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Publish API
+        run: ./mvnw -f liquidjava-api/pom.xml -B --fail-fast -Dgpg.skip=false -Dmaven.deploy.skip=false clean deploy
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-verifier.yml
+++ b/.github/workflows/publish-verifier.yml
@@ -1,0 +1,45 @@
+name: Publish verifier
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish liquidjava-verifier to Maven Central
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag is on main
+        run: |
+          git fetch origin main
+          TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          git merge-base --is-ancestor "$TAG_COMMIT" origin/main
+
+      - name: Set up JDK 20
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "20"
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Publish verifier
+        run: ./mvnw -f liquidjava-verifier/pom.xml -B --fail-fast -Dgpg.skip=false -Dmaven.deploy.skip=false clean deploy
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "automatic"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.autobuild.enabled": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,33 @@ Verify a single file from the CLI:
 
 Code formatting runs automatically via `formatter-maven-plugin` during the `validate` phase.
 
+## Release
+
+Releases are published through GitHub Actions when release tags are pushed to
+`main`:
+
+- `v*` tags publish `liquidjava-verifier` through the `publish-verifier`
+  workflow.
+- `api-v*` tags publish `liquidjava-api` through the `publish-api` workflow.
+
+Use `release.sh` from the repository root to publish a release.
+The script automatically verifies the build and tests, bumps the module version, commits the version change, creates the matching tag, and pushes them to `main`.
+
+```bash
+./release.sh verifier # publishes liquidjava-verifier
+./release.sh api      # publishes liquidjava-api
+```
+
+You can also pass the release version explicitly:
+
+```bash
+./release.sh verifier 1.2.3
+./release.sh api 1.2.3
+```
+
+Run releases from a clean `main` branch. Once the tag is pushed, the matching
+GitHub Actions workflow publishes the module to Maven Central.
+
 ## Adding test cases
 
 Tests live under `liquidjava-example/src/main/java/testSuite/` and are auto-discovered:

--- a/liquidjava-api/pom.xml
+++ b/liquidjava-api/pom.xml
@@ -142,7 +142,8 @@
 				<configuration>
 					<publishingServerId>central</publishingServerId>
 					<skipPublishing>${maven.deploy.skip}</skipPublishing>
-					<!-- <autoPublish>true</autoPublish> -->
+					<autoPublish>true</autoPublish>
+					<waitUntil>published</waitUntil>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/liquidjava-verifier/pom.xml
+++ b/liquidjava-verifier/pom.xml
@@ -213,7 +213,8 @@
 				<configuration>
 					<publishingServerId>central</publishingServerId>
 					<skipPublishing>${maven.deploy.skip}</skipPublishing>
-					<!-- <autoPublish>true</autoPublish> -->
+					<autoPublish>true</autoPublish>
+					<waitUntil>published</waitUntil>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/release.sh
+++ b/release.sh
@@ -2,18 +2,43 @@
 
 set -euo pipefail
 
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <api|verifier> <version>"
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+    echo "Usage: $0 <api|verifier> [version]"
     exit 1
 fi
 
 MODULE=$1
-VERSION=$2
+VERSION=${2:-}
 
 if [ "$MODULE" != "api" ] && [ "$MODULE" != "verifier" ]; then
     echo "Invalid module: $MODULE"
-    echo "Usage: $0 <api|verifier> <version>"
+    echo "Usage: $0 <api|verifier> [version]"
     exit 1
+fi
+
+MODULE_DIR="liquidjava-$MODULE"
+POM="$MODULE_DIR/pom.xml"
+
+if [ -z "$VERSION" ]; then
+    CURRENT_VERSION=$(perl -0ne "print \$1 if m#<artifactId>\\Q$MODULE_DIR\\E</artifactId>\\s*<version>([^<]+)</version>#" "$POM")
+
+    if [ -z "$CURRENT_VERSION" ]; then
+        echo "Could not read current version from $POM"
+        exit 1
+    fi
+
+    if ! [[ "$CURRENT_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+        echo "Cannot automatically bump non-numeric version: $CURRENT_VERSION"
+        echo "Pass the release version explicitly."
+        exit 1
+    fi
+
+    IFS=. read -ra VERSION_PARTS <<<"$CURRENT_VERSION"
+    LAST_INDEX=$((${#VERSION_PARTS[@]} - 1))
+    VERSION_PARTS[$LAST_INDEX]=$((${VERSION_PARTS[$LAST_INDEX]} + 1))
+    VERSION=$(IFS=.; echo "${VERSION_PARTS[*]}")
+
+    echo "Bumping $MODULE_DIR from $CURRENT_VERSION to $VERSION"
 fi
 
 if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}(-[A-Za-z0-9.-]+)?$ ]]; then
@@ -21,9 +46,6 @@ if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}(-[A-Za-z0-9.-]+)?$ ]]; then
     echo "Expected format: 1.2.3"
     exit 1
 fi
-
-MODULE_DIR="liquidjava-$MODULE"
-POM="$MODULE_DIR/pom.xml"
 
 if [ "$MODULE" = "api" ]; then
     TAG="api-v$VERSION"
@@ -48,14 +70,14 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
     exit 1
 fi
 
+./mvnw -f "$POM" -B --fail-fast -Dgpg.skip=true -Dmaven.deploy.skip=true clean verify
+
 perl -0pi -e "s#(<artifactId>$MODULE_DIR</artifactId>\\s*<version>)[^<]+(</version>)#\${1}$VERSION\${2}#" "$POM"
 
 if git diff --quiet -- "$POM"; then
     echo "$POM is already at version $VERSION"
     exit 1
 fi
-
-./mvnw -f "$POM" -B --fail-fast -Dgpg.skip=true -Dmaven.deploy.skip=true clean verify
 
 git add "$POM"
 git commit -m "Release $MODULE_DIR $VERSION"

--- a/release.sh
+++ b/release.sh
@@ -1,20 +1,67 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 <api|verifier>"
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <api|verifier> <version>"
     exit 1
 fi
 
 MODULE=$1
+VERSION=$2
 
 if [ "$MODULE" != "api" ] && [ "$MODULE" != "verifier" ]; then
     echo "Invalid module: $MODULE"
-    echo "Usage: $0 <api|verifier>"
+    echo "Usage: $0 <api|verifier> <version>"
+    exit 1
+fi
+
+if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}(-[A-Za-z0-9.-]+)?$ ]]; then
+    echo "Invalid version: $VERSION"
+    echo "Expected format: 1.2.3"
     exit 1
 fi
 
 MODULE_DIR="liquidjava-$MODULE"
+POM="$MODULE_DIR/pom.xml"
 
-cd "$MODULE_DIR"
-mvn -Dgpg.skip=false -Dmaven.deploy.skip=false clean deploy
-cd ..
+if [ "$MODULE" = "api" ]; then
+    TAG="api-v$VERSION"
+else
+    TAG="v$VERSION"
+fi
+
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "Release must be run from main. Current branch: $CURRENT_BRANCH"
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Worktree must be clean before releasing."
+    git status --short
+    exit 1
+fi
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    echo "Tag already exists: $TAG"
+    exit 1
+fi
+
+perl -0pi -e "s#(<artifactId>$MODULE_DIR</artifactId>\\s*<version>)[^<]+(</version>)#\${1}$VERSION\${2}#" "$POM"
+
+if git diff --quiet -- "$POM"; then
+    echo "$POM is already at version $VERSION"
+    exit 1
+fi
+
+./mvnw -f "$POM" -B --fail-fast -Dgpg.skip=true -Dmaven.deploy.skip=true clean verify
+
+git add "$POM"
+git commit -m "Release $MODULE_DIR $VERSION"
+git tag "$TAG"
+
+git push origin main
+git push origin "$TAG"
+
+echo "Created and pushed $TAG. GitHub Actions will publish $MODULE_DIR to Maven Central."


### PR DESCRIPTION
## Description
This PR adds two GitHub Actions workflows `publish-verifier` and `publish-api` for automatically releasing each one when the tags `v*` or `api-v*` are pushed to `main`, respectively. It also updates the `release.sh` script to verify build and tests, bump the module version, commit, tag, and push to `main` automatically.

## Example
```sh
./release.sh verifier # publishes liquidjava-verifier
./release.sh api      # publishes liquidjava-api
```

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
