### PR TITLE
Propagate Expressions

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
@@ -379,7 +379,7 @@ public class RefinementTypeChecker extends TypeChecker {
                 thenRefs = Predicate.createConjunction(expRefs, freshIsTrue);
                 elseRefs = Predicate.createConjunction(expRefs, freshIsFalse);
             }
-            
+
             freshRV = context.addInstanceToContext(pathVarName, factory.Type().BOOLEAN_PRIMITIVE, thenRefs, exp);
         }
         vcChecker.addPathVariable(freshRV);

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/ExpressionFolding.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/ExpressionFolding.java
@@ -146,6 +146,10 @@ public class ExpressionFolding {
                 return new ValDerivationNode(res, new BinaryDerivationNode(leftNode, rightNode, op));
         }
 
+        ValDerivationNode adjacentConstants = foldAdjacentIntegerConstants(leftNode, rightNode, op);
+        if (adjacentConstants != null)
+            return adjacentConstants;
+
         // no folding
         DerivationNode origin = (leftNode.getOrigin() != null || rightNode.getOrigin() != null)
                 ? new BinaryDerivationNode(leftNode, rightNode, op) : null;
@@ -242,5 +246,33 @@ public class ExpressionFolding {
 
     private static boolean hasIteChildOrigin(ValDerivationNode cond, ValDerivationNode then, ValDerivationNode els) {
         return cond.getOrigin() != null || then.getOrigin() != null || els.getOrigin() != null;
+    }
+
+    private static ValDerivationNode foldAdjacentIntegerConstants(ValDerivationNode leftNode,
+            ValDerivationNode rightNode, String op) {
+        if (!"+".equals(op) && !"-".equals(op))
+            return null;
+        if (!(rightNode.getValue()instanceof LiteralInt rightLiteral))
+            return null;
+        if (!(leftNode.getValue()instanceof BinaryExpression leftBinary))
+            return null;
+        if (!"+".equals(leftBinary.getOperator()) && !"-".equals(leftBinary.getOperator()))
+            return null;
+        if (!(leftBinary.getSecondOperand()instanceof LiteralInt leftLiteral))
+            return null;
+
+        int signedLeft = "+".equals(leftBinary.getOperator()) ? leftLiteral.getValue() : -leftLiteral.getValue();
+        int signedRight = "+".equals(op) ? rightLiteral.getValue() : -rightLiteral.getValue();
+        Expression folded = expressionWithConstant(leftBinary.getFirstOperand(), signedLeft + signedRight);
+
+        return new ValDerivationNode(folded, new BinaryDerivationNode(leftNode, rightNode, op));
+    }
+
+    private static Expression expressionWithConstant(Expression base, int constant) {
+        if (constant == 0)
+            return base.clone();
+        if (constant > 0)
+            return new BinaryExpression(base.clone(), "+", new LiteralInt(constant));
+        return new BinaryExpression(base.clone(), "-", new LiteralInt(-constant));
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
@@ -23,7 +23,7 @@ public class VariablePropagation {
      */
     public static ValDerivationNode propagate(Expression exp, ValDerivationNode previousOrigin) {
         Map<String, Expression> substitutions = VariableResolver.resolve(exp);
-        Map<String, Expression> directSubstitutions = new HashMap<>(); // var == value or var == var 
+        Map<String, Expression> directSubstitutions = new HashMap<>(); // var == literal or var == var 
         Map<String, Expression> expressionSubstitutions = new HashMap<>(); // var == expression
         for (Map.Entry<String, Expression> entry : substitutions.entrySet()) {
             Expression value = entry.getValue();

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
@@ -23,13 +23,25 @@ public class VariablePropagation {
      */
     public static ValDerivationNode propagate(Expression exp, ValDerivationNode previousOrigin) {
         Map<String, Expression> substitutions = VariableResolver.resolve(exp);
+        Map<String, Expression> constantSubstitutions = new HashMap<>();
+        Map<String, Expression> expressionSubstitutions = new HashMap<>();
+        for (Map.Entry<String, Expression> entry : substitutions.entrySet()) {
+            Expression value = entry.getValue();
+            if (value.isLiteral() || value instanceof Var) {
+                constantSubstitutions.put(entry.getKey(), value);
+            } else {
+                expressionSubstitutions.put(entry.getKey(), value);
+            }
+        }
 
         // map of variable origins from the previous derivation tree
         Map<String, DerivationNode> varOrigins = new HashMap<>();
         if (previousOrigin != null) {
             extractVarOrigins(previousOrigin, varOrigins);
         }
-        return propagateRecursive(exp, substitutions, varOrigins);
+        Map<String, Expression> activeSubstitutions = constantSubstitutions.isEmpty() ? expressionSubstitutions
+                : constantSubstitutions;
+        return propagateRecursive(exp, activeSubstitutions, varOrigins);
     }
 
     /**

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
@@ -23,12 +23,12 @@ public class VariablePropagation {
      */
     public static ValDerivationNode propagate(Expression exp, ValDerivationNode previousOrigin) {
         Map<String, Expression> substitutions = VariableResolver.resolve(exp);
-        Map<String, Expression> constantSubstitutions = new HashMap<>();
-        Map<String, Expression> expressionSubstitutions = new HashMap<>();
+        Map<String, Expression> directSubstitutions = new HashMap<>(); // var == value or var == var 
+        Map<String, Expression> expressionSubstitutions = new HashMap<>(); // var == expression
         for (Map.Entry<String, Expression> entry : substitutions.entrySet()) {
             Expression value = entry.getValue();
             if (value.isLiteral() || value instanceof Var) {
-                constantSubstitutions.put(entry.getKey(), value);
+                directSubstitutions.put(entry.getKey(), value);
             } else {
                 expressionSubstitutions.put(entry.getKey(), value);
             }
@@ -39,8 +39,8 @@ public class VariablePropagation {
         if (previousOrigin != null) {
             extractVarOrigins(previousOrigin, varOrigins);
         }
-        Map<String, Expression> activeSubstitutions = constantSubstitutions.isEmpty() ? expressionSubstitutions
-                : constantSubstitutions;
+        Map<String, Expression> activeSubstitutions = directSubstitutions.isEmpty() ? expressionSubstitutions
+                : directSubstitutions;
         return propagateRecursive(exp, activeSubstitutions, varOrigins);
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
@@ -66,6 +66,8 @@ public class VariableResolver {
                     if (!isReturnVar(lowerVar) && !isFreshVar(higherVar))
                         map.putIfAbsent(lowerVar.getName(), higherVar.clone());
                 }
+            } else if (left instanceof Var var && !(right instanceof Var) && canSubstitute(var, right)) {
+                map.put(var.getName(), right.clone());
             }
         }
     }
@@ -124,7 +126,8 @@ public class VariableResolver {
         if (exp instanceof BinaryExpression binary && "==".equals(binary.getOperator())) {
             Expression left = binary.getFirstOperand();
             Expression right = binary.getSecondOperand();
-            if (left instanceof Var v && v.getName().equals(name) && right.isLiteral())
+            if (left instanceof Var v && v.getName().equals(name)
+                    && (right.isLiteral() || (!(right instanceof Var) && canSubstitute(v, right))))
                 return false;
             if (right instanceof Var v && v.getName().equals(name) && left.isLiteral())
                 return false;
@@ -163,5 +166,23 @@ public class VariableResolver {
 
     private static boolean isFreshVar(Var var) {
         return var.getName().startsWith("#fresh_");
+    }
+
+    private static boolean canSubstitute(Var var, Expression value) {
+        return !isReturnVar(var) && !isFreshVar(var) && !containsVariable(value, var.getName());
+    }
+
+    private static boolean containsVariable(Expression exp, String name) {
+        if (exp instanceof Var var)
+            return var.getName().equals(name);
+
+        if (!exp.hasChildren())
+            return false;
+
+        for (Expression child : exp.getChildren()) {
+            if (containsVariable(child, name))
+                return true;
+        }
+        return false;
     }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -1089,4 +1089,25 @@ class ExpressionSimplifierTest {
 
         assertDerivationEquals(expected, result, "Equivalent bounds simplification should preserve conjunction origin");
     }
+
+    @Test
+    void testSubstitutesVariableDefinedByArithmeticExpression() {
+        // Given: z == y - 2 && y == x + 1
+        // Expected: z == x + 1 - 2
+
+        Expression z = new Var("z");
+        Expression y = new Var("y");
+        Expression x = new Var("x");
+
+        Expression returnExpression = new BinaryExpression(z, "==", new BinaryExpression(y, "-", new LiteralInt(2)));
+        Expression yDefinition = new BinaryExpression(y, "==", new BinaryExpression(x, "+", new LiteralInt(1)));
+        Expression fullExpression = new BinaryExpression(returnExpression, "&&", yDefinition);
+
+        // When
+        ValDerivationNode result = ExpressionSimplifier.simplify(fullExpression);
+
+        // Then
+        assertNotNull(result, "Result should not be null");
+        assertEquals("z == x + 1 - 2", result.getValue().toString(), "Expected variable definition to be substituted");
+    }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -1093,7 +1093,7 @@ class ExpressionSimplifierTest {
     @Test
     void testSubstitutesVariableDefinedByArithmeticExpression() {
         // Given: z == y - 2 && y == x + 1
-        // Expected: z == x + 1 - 2
+        // Expected: z == x - 1
 
         Expression z = new Var("z");
         Expression y = new Var("y");
@@ -1108,6 +1108,29 @@ class ExpressionSimplifierTest {
 
         // Then
         assertNotNull(result, "Result should not be null");
-        assertEquals("z == x + 1 - 2", result.getValue().toString(), "Expected variable definition to be substituted");
+        assertEquals("z == x - 1", result.getValue().toString(), "Expected variable definition to be substituted");
+    }
+
+    @Test
+    void testFoldsAdjacentIntegerConstantsInLeftAssociatedArithmetic() {
+        // Given: x + 1 - 2, x - 1 + 2, x + 1 + 2, and x + 1 - 1
+        // Expected: x - 1, x + 1, x + 3, and x
+
+        Expression x = new Var("x");
+
+        Expression xPlus1Minus2 = new BinaryExpression(new BinaryExpression(x, "+", new LiteralInt(1)), "-",
+                new LiteralInt(2));
+        Expression xMinus1Plus2 = new BinaryExpression(new BinaryExpression(x, "-", new LiteralInt(1)), "+",
+                new LiteralInt(2));
+        Expression xPlus1Plus2 = new BinaryExpression(new BinaryExpression(x, "+", new LiteralInt(1)), "+",
+                new LiteralInt(2));
+        Expression xPlus1Minus1 = new BinaryExpression(new BinaryExpression(x, "+", new LiteralInt(1)), "-",
+                new LiteralInt(1));
+
+        // When / Then
+        assertEquals("x - 1", ExpressionSimplifier.simplify(xPlus1Minus2).getValue().toString());
+        assertEquals("x + 1", ExpressionSimplifier.simplify(xMinus1Plus2).getValue().toString());
+        assertEquals("x + 3", ExpressionSimplifier.simplify(xPlus1Plus2).getValue().toString());
+        assertEquals("x", ExpressionSimplifier.simplify(xPlus1Minus1).getValue().toString());
     }
 }


### PR DESCRIPTION
## Description
This PR enables the propagation of expressions, instead of only literals or other variables.
With this, we can propagate all the following: `var == literal`, `var == var`, and now `var == expression`.
For example, the assignment `x == y + 1` now adds the mapping `x → y + 1`, allowing the RHS to be propagated wherever `x` appears.

## Example

#### Before

```
Refinement Error: #ret³ == y² - 2 && y² == x + 1 is not a subtype of #ret³ > 0
```

#### After

```
Refinement Error: #ret³ == x - 1 is not a subtype of #ret³ > 0
```

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added tests in `ExpressionSimplifierTest`
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
