### PR TITLE
Distinguish Definitions from Usages in Variable Resolver

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
@@ -26,7 +26,7 @@ public class VariableResolver {
         resolveRecursive(exp, map);
 
         // remove variables that were not used in the expression
-        map.entrySet().removeIf(entry -> !hasUsage(exp, entry.getKey()));
+        map.entrySet().removeIf(entry -> !hasUsage(exp, entry.getKey(), entry.getValue()));
 
         // transitively resolve variables
         return resolveTransitive(map);
@@ -138,20 +138,21 @@ public class VariableResolver {
      *
      * @return true if used, false otherwise
      */
-    private static boolean hasUsage(Expression exp, String name) {
+    private static boolean hasUsage(Expression exp, String name, Expression value) {
         // exclude own definitions
         if (exp instanceof BinaryExpression binary && "==".equals(binary.getOperator())) {
             Expression left = binary.getFirstOperand();
             Expression right = binary.getSecondOperand();
-            if (left instanceof Var v && v.getName().equals(name)
+            if (left instanceof Var v && v.getName().equals(name) && right.equals(value)
                     && (right.isLiteral() || (!(right instanceof Var) && canSubstitute(v, right))))
                 return false;
-            if (left instanceof FunctionInvocation && left.toString().equals(name)
+            if (left instanceof FunctionInvocation && left.toString().equals(name) && right.equals(value)
                     && (right.isLiteral() || (!(right instanceof Var) && !containsExpression(right, left))))
                 return false;
-            if (right instanceof Var v && v.getName().equals(name) && left.isLiteral())
+            if (right instanceof Var v && v.getName().equals(name) && left.equals(value) && left.isLiteral())
                 return false;
-            if (right instanceof FunctionInvocation && right.toString().equals(name) && left.isLiteral())
+            if (right instanceof FunctionInvocation && right.toString().equals(name) && left.equals(value)
+                    && left.isLiteral())
                 return false;
         }
 
@@ -166,7 +167,7 @@ public class VariableResolver {
         // recurse children
         if (exp.hasChildren()) {
             for (Expression child : exp.getChildren())
-                if (hasUsage(child, name))
+                if (hasUsage(child, name, value))
                     return true;
         }
 

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -458,6 +458,16 @@ class ExpressionSimplifierTest {
     }
 
     @Test
+    void testIteConditionUsesEqualityFromConjunction() {
+        Expression expr = parse("mode == 1 && (mode == 2 ? explicit(param) : start(param))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expr);
+
+        assertNotNull(result, "Result should not be null");
+        assertEquals("start(param)", result.getValue().toString(),
+                "mode == 1 should make the mode == 2 ternary condition false");
+    }
+
+    @Test
     void testByteAliasExpansion() {
         String sut = "Byte(b)";
         AliasDTO byteAlias = new AliasDTO("Byte", List.of("int"), List.of("b"), "b >= -128 && b <= 127");

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
@@ -91,6 +91,15 @@ class VariableResolverTest {
     }
 
     @Test
+    void testDifferentEqualityInIteConditionCountsAsUsage() {
+        Expression expression = parse("mode == 1 && (mode == 2 ? explicit(param) : start(param))");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(1, result.size(), "Ternary condition should count as a use of mode");
+        assertEquals("1", result.get("mode").toString());
+    }
+
+    @Test
     void testReturnVariableIsNotSubstituted() {
         Expression expression = parse("x > 0 && #ret_1 == x");
         Map<String, Expression> result = VariableResolver.resolve(expression);


### PR DESCRIPTION
## Description
This PR fixes a problem in the simplification where value propagation could be skipped for expressions like `x == 1 && x == 2`. The resolver treated any equality involving `x` and a literal as the definition of `x`, even when only one of those equalities was the actual definition being propagated.

Now the resolver tracks the value that defined the substitution and uses it to distinguish the defining equality from later usages. For a direct contradiction like `x == 1 && x == 2`, either value can be picked for propagation: both expose the contradiction and fold to `false`.

## Example

### Before

```
mode⁷⁰ == 1 &&
(mode⁷⁰ == 2 ? compressionExplicit(param⁷¹) : startCompression(param⁷¹)) &&
state1(param⁷¹) == state1(param⁶⁹) &&
startTiling(param⁶⁹) &&
startCompression(param⁶⁹)
```

### After

```
startCompression(param⁷¹) &&
state1(param⁷¹) == state1(param⁶⁹) &&
startTiling(param⁶⁹) &&
startCompression(param⁶⁹)
```

## Related Issue
None.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests in `ExpressionSimplifierTest` and `VariableResolverTest`
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
