### PR TITLE
Derive Developer Facing States

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -391,8 +391,10 @@ public class VCChecker {
         gatherVariables(found, lrv, mainVars);
         TranslationTable map = new TranslationTable();
         VCImplication foundState = joinPredicates(found, mainVars, lrv, map);
-        throw new StateRefinementError(position, expected.getExpression(),
-                foundState.toConjunctions().simplify(context).getValue(), map, customMessage);
+        Predicate foundConjunction = new Predicate(foundState.toConjunctions().simplify(context).getValue())
+                .addDerivedStateEqualities(context.getGhostStates());
+        throw new StateRefinementError(position, expected.getExpression(), foundConjunction.getExpression(), map,
+                customMessage);
     }
 
     protected void throwStateConflictError(SourcePosition position, Predicate expected) throws StateConflictError {

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
@@ -221,6 +221,70 @@ public class Predicate {
         return new Predicate(e);
     }
 
+    public Predicate addDerivedStateEqualities(List<GhostState> ghostStates) {
+        List<Expression> conjuncts = exp.getConjuncts();
+        Map<String, String> stateToInternalState = new HashMap<>();
+        for (GhostState gs : ghostStates) {
+            if (gs.getRefinement() == null)
+                continue;
+            Expression ref = gs.getRefinement().getExpression();
+            if (ref instanceof GroupExpression ge)
+                ref = ge.getExpression();
+            if (ref instanceof BinaryExpression be && Ops.EQ.equals(be.getOperator())) {
+                FunctionInvocation state = functionInvocation(be.getFirstOperand());
+                if (state == null)
+                    state = functionInvocation(be.getSecondOperand());
+                if (state != null)
+                    stateToInternalState.put(gs.getName(), state.getName());
+            }
+        }
+
+        Predicate result = new Predicate();
+        List<Predicate> derivedStates = new ArrayList<>();
+        for (Expression conjunct : conjuncts) {
+            boolean replaced = false;
+            if (conjunct instanceof BinaryExpression be && Ops.EQ.equals(be.getOperator())) {
+                FunctionInvocation left = functionInvocation(be.getFirstOperand());
+                FunctionInvocation right = functionInvocation(be.getSecondOperand());
+                if (left != null && right != null && left.getArgs().size() == 1 && right.getArgs().size() == 1
+                        && sameName(left.getName(), right.getName())) {
+                    for (Expression stateConjunct : conjuncts) {
+                        FunctionInvocation state = functionInvocation(stateConjunct);
+                        if (state == null || state.getArgs().size() != 1)
+                            continue;
+                        for (Map.Entry<String, String> stateName : stateToInternalState.entrySet()) {
+                            if (!sameName(stateName.getKey(), state.getName())
+                                    || !sameName(stateName.getValue(), left.getName()))
+                                continue;
+
+                            Expression known = state.getArgs().get(0);
+                            Expression target = known.equals(left.getArgs().get(0)) ? right.getArgs().get(0)
+                                    : known.equals(right.getArgs().get(0)) ? left.getArgs().get(0) : null;
+                            if (target != null) {
+                                derivedStates.add(createInvocation(state.getName(), new Predicate(target)));
+                                replaced = true;
+                            }
+                        }
+                    }
+                }
+            }
+            if (!replaced)
+                result = createConjunction(result, new Predicate(conjunct));
+        }
+        for (Predicate derivedState : derivedStates)
+            result = createConjunction(result, derivedState);
+        return result;
+    }
+
+    private static FunctionInvocation functionInvocation(Expression exp) {
+        return exp instanceof GroupExpression ge ? functionInvocation(ge.getExpression())
+                : exp instanceof FunctionInvocation fi ? fi : null;
+    }
+
+    private static boolean sameName(String first, String second) {
+        return first.equals(second) || Utils.getSimpleName(first).equals(Utils.getSimpleName(second));
+    }
+
     public boolean isBooleanTrue() {
         return exp.isBooleanTrue();
     }


### PR DESCRIPTION
## Description
This PR improves error messages by deriving developer-facing states from internal state equalities.
When an error contains an internal equality like `state1(new) == state1(old)` plus a known developer state for `old`, the diagnostic now displays the corresponding developer state for new and omits the internal equality once it has served that purpose.

This is for error messages only and does not change SMT verification behavior.

## Example

#### Before
```
startCompression(param⁷¹) &&
state1(param⁷¹) == state1(param⁶⁹) &&
startTiling(param⁶⁹) &&
startCompression(param⁶⁹)
```

#### After
```
startCompression(param⁷¹) &&
startTiling(param⁶⁹) &&
startCompression(param⁶⁹) &&
startTiling(param⁷¹)
```

## Related Issue
Closes #206.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
