### PR TITLE
Simplify Enums & Static Final Fields

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/ExpressionFolding.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/ExpressionFolding.java
@@ -1,6 +1,7 @@
 package liquidjava.rj_language.opt;
 
 import liquidjava.rj_language.ast.BinaryExpression;
+import liquidjava.rj_language.ast.Enum;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.GroupExpression;
 import liquidjava.rj_language.ast.Ite;
@@ -62,6 +63,16 @@ public class ExpressionFolding {
         Expression left = leftNode.getValue();
         Expression right = rightNode.getValue();
         String op = binExp.getOperator();
+
+        if (left instanceof Enum en && en.getResolvedLiteral() != null) {
+            left = en.getResolvedLiteral().clone();
+            leftNode = new ValDerivationNode(left, leftNode);
+        }
+        if (right instanceof Enum en && en.getResolvedLiteral() != null) {
+            right = en.getResolvedLiteral().clone();
+            rightNode = new ValDerivationNode(right, rightNode);
+        }
+
         binExp.setChild(0, left);
         binExp.setChild(1, right);
 
@@ -140,6 +151,18 @@ public class ExpressionFolding {
             case "-->" -> new LiteralBoolean(!l || r);
             case "==" -> new LiteralBoolean(l == r);
             case "!=" -> new LiteralBoolean(l != r);
+            default -> null;
+            };
+            if (res != null)
+                return new ValDerivationNode(res, new BinaryDerivationNode(leftNode, rightNode, op));
+        }
+
+        else if (left instanceof Enum leftEnum && right instanceof Enum rightEnum
+                && leftEnum.getTypeName().equals(rightEnum.getTypeName())) {
+            boolean equal = leftEnum.getConstName().equals(rightEnum.getConstName());
+            Expression res = switch (op) {
+            case "==" -> new LiteralBoolean(equal);
+            case "!=" -> new LiteralBoolean(!equal);
             default -> null;
             };
             if (res != null)

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
@@ -1,6 +1,7 @@
 package liquidjava.rj_language.opt;
 
 import liquidjava.rj_language.ast.BinaryExpression;
+import liquidjava.rj_language.ast.Enum;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.FunctionInvocation;
 import liquidjava.rj_language.ast.UnaryExpression;
@@ -28,7 +29,7 @@ public class VariablePropagation {
         Map<String, Expression> expressionSubstitutions = new HashMap<>(); // var == expression
         for (Map.Entry<String, Expression> entry : substitutions.entrySet()) {
             Expression value = entry.getValue();
-            if (value.isLiteral() || value instanceof Var) {
+            if (value.isLiteral() || value instanceof Var || value instanceof Enum) {
                 directSubstitutions.put(entry.getKey(), value);
             } else {
                 expressionSubstitutions.put(entry.getKey(), value);

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import liquidjava.rj_language.ast.BinaryExpression;
+import liquidjava.rj_language.ast.Enum;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.FunctionInvocation;
 import liquidjava.rj_language.ast.Var;
@@ -56,9 +57,9 @@ public class VariableResolver {
         String leftKey = substitutionKey(left);
         String rightKey = substitutionKey(right);
 
-        if (leftKey != null && right.isLiteral()) {
+        if (leftKey != null && isConstant(right)) {
             map.put(leftKey, right.clone());
-        } else if (rightKey != null && left.isLiteral()) {
+        } else if (rightKey != null && isConstant(left)) {
             map.put(rightKey, left.clone());
         } else if (left instanceof Var leftVar && right instanceof Var rightVar) {
             // to substitute internal variable with user-facing variable
@@ -144,15 +145,15 @@ public class VariableResolver {
             Expression left = binary.getFirstOperand();
             Expression right = binary.getSecondOperand();
             if (left instanceof Var v && v.getName().equals(name) && right.equals(value)
-                    && (right.isLiteral() || (!(right instanceof Var) && canSubstitute(v, right))))
+                    && (isConstant(right) || (!(right instanceof Var) && canSubstitute(v, right))))
                 return false;
             if (left instanceof FunctionInvocation && left.toString().equals(name) && right.equals(value)
-                    && (right.isLiteral() || (!(right instanceof Var) && !containsExpression(right, left))))
+                    && (isConstant(right) || (!(right instanceof Var) && !containsExpression(right, left))))
                 return false;
-            if (right instanceof Var v && v.getName().equals(name) && left.equals(value) && left.isLiteral())
+            if (right instanceof Var v && v.getName().equals(name) && left.equals(value) && isConstant(left))
                 return false;
             if (right instanceof FunctionInvocation && right.toString().equals(name) && left.equals(value)
-                    && left.isLiteral())
+                    && isConstant(left))
                 return false;
         }
 
@@ -196,6 +197,10 @@ public class VariableResolver {
 
     private static boolean canSubstitute(Var var, Expression value) {
         return !isReturnVar(var) && !isFreshVar(var) && !containsVariable(value, var.getName());
+    }
+
+    private static boolean isConstant(Expression exp) {
+        return exp.isLiteral() || exp instanceof Enum;
     }
 
     private static boolean containsVariable(Expression exp, String name) {

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -626,4 +626,36 @@ class ExpressionSimplifierTest {
 
         assertEquals("3", result.getValue().toString());
     }
+
+    @Test
+    void testEnumConstantsPropagateIntoVariableEquality() {
+        Expression expression = parse("current == mode && mode == Mode.Photo");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("current == Mode.Photo", result.getValue().toString());
+    }
+
+    @Test
+    void testEnumConstantsPropagateTransitively() {
+        Expression expression = parse("target == current && current == mode && mode == Mode.Photo");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("target == Mode.Photo", result.getValue().toString());
+    }
+
+    @Test
+    void testEnumConstantsPropagateThroughFunctionInvocations() {
+        Expression expression = parse("modeOf(x) == Mode.Photo && current == modeOf(x)");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("current == Mode.Photo", result.getValue().toString());
+    }
+
+    @Test
+    void testEnumConstantsPropagateIntoTernaryCondition() {
+        Expression expression = parse("mode == Mode.Photo && (mode == Mode.Video ? explicit(param) : start(param))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("start(param)", result.getValue().toString());
+    }
 }


### PR DESCRIPTION
## Description
This PR updates the expression simplification so enums and static final fields are treated as constants during variable propagation and expression folding.

## Example
- `current == mode && mode == Mode.Photo` → `current == Mode.Photo`
- `mode == Mode.Photo && (mode == Mode.Video ? explicit(param) : start(param))` → `start(param)`

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests in `ExpressionSimplifierTest`
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
