### PR TITLE
Update Run Script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Verify a single file from the CLI:
 ./liquidjava path/to/File.java
 ```
 
+The launcher recompiles `liquidjava-api` and `liquidjava-verifier` only when local sources or Maven files have changed.
 Code formatting runs automatically via `formatter-maven-plugin` during the `validate` phase.
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ mvn exec:java -pl liquidjava-verifier -Dexec.mainClass="liquidjava.api.CommandLi
 ```
 
 If you're on Linux/macOS, you can use the `liquidjava` script (from the repository root) to simplify the process.
+The script recompiles the verifier only when local sources or Maven files have changed.
 
 **Test a correct case**:
 ```bash

--- a/liquidjava
+++ b/liquidjava
@@ -1,4 +1,20 @@
 #!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+MARKER="liquidjava-verifier/target/.liquidjava-last-compile"
+
+if [ ! -d liquidjava-api/target/classes ] || \
+   [ ! -d liquidjava-verifier/target/classes ] || \
+   [ ! -f "$MARKER" ] || \
+   find pom.xml liquidjava-api/pom.xml liquidjava-api/src/main/java \
+     liquidjava-verifier/pom.xml liquidjava-verifier/src/main/java liquidjava-verifier/src/main/antlr4 \
+     -newer "$MARKER" -print -quit | grep -q .; then
+  mvn compile -pl liquidjava-verifier -am -Dmaven.compiler.useIncrementalCompilation=false
+  touch "$MARKER"
+fi
+
 mvn exec:java -pl liquidjava-verifier \
   -Dexec.mainClass="liquidjava.api.CommandLineLauncher" \
   -Dexec.args="$*"


### PR DESCRIPTION
## Description
This PR updates the `liquidjava` script to run `mvn compile`, but only when local sources have changed.
This makes the verification run against the latest changes while avoiding unnecessary compilations.

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [x] Updated docs/README if behavior or API changed
