### PR TITLE
Improve Debug Logs

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
@@ -10,7 +10,6 @@ import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.ast.BinaryExpression;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.GroupExpression;
-import liquidjava.rj_language.opt.derivation_node.ValDerivationNode;
 import liquidjava.smt.Counterexample;
 import liquidjava.utils.Utils;
 import spoon.reflect.cu.SourcePosition;
@@ -135,23 +134,8 @@ public final class DebugLog {
         if (!enabled()) {
             return;
         }
-        System.out.println(SMP_TAG + " Simplified " + Colors.CYAN + input + Colors.RESET + " to " + Colors.YELLOW
-                + output + Colors.RESET);
-    }
-
-    /**
-     * Print every assignment returned by the solver before error reporting filters the user-facing counterexample down
-     * to the variables mentioned in the diagnostic.
-     */
-    public static void counterexample(Counterexample counterexample) {
-        if (!enabled() || counterexample == null || counterexample.assignments().isEmpty()) {
-            return;
-        }
-        System.out
-                .println(SMP_TAG
-                        + " Counterexample: " + Colors.RED + counterexample.assignments().stream()
-                                .map(a -> a.first() + " = " + a.second()).collect(Collectors.joining(" && "))
-                        + Colors.RESET);
+        System.out.println(SMP_TAG + " Before simplification: " + Colors.YELLOW + input + Colors.RESET);
+        System.out.println(SMP_TAG + " After simplification:  " + Colors.BOLD_YELLOW + output + Colors.RESET);
     }
 
     private static String plainLabel(VCImplication node) {

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
@@ -135,7 +135,7 @@ public final class DebugLog {
         if (!enabled() || counterexample == null || counterexample.assignments().isEmpty()) {
             return;
         }
-        System.out.println(SMT_TAG + " counterexample assignments:");
+        System.out.println(SMT_TAG + " unfiltered counterexample assignments:");
         for (var assignment : counterexample.assignments()) {
             System.out.println(SMT_TAG + "     " + assignment.first() + " = " + assignment.second());
         }

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
@@ -2,6 +2,7 @@ package liquidjava.diagnostics;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import liquidjava.api.CommandLineLauncher;
 import liquidjava.processor.VCImplication;
@@ -9,6 +10,7 @@ import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.ast.BinaryExpression;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.GroupExpression;
+import liquidjava.rj_language.opt.derivation_node.ValDerivationNode;
 import liquidjava.smt.Counterexample;
 import liquidjava.utils.Utils;
 import spoon.reflect.cu.SourcePosition;
@@ -30,6 +32,7 @@ public final class DebugLog {
 
     private static final String SMT_TAG = Colors.BLUE + "[SMT]" + Colors.RESET;
     private static final String SMT_CHECK = Colors.SALMON + "[SMT CHECK]" + Colors.RESET;
+    private static final String SMP_TAG = Colors.YELLOW + "[SMP]" + Colors.RESET;
 
     private DebugLog() {
     }
@@ -124,21 +127,31 @@ public final class DebugLog {
         System.out.println(SMT_TAG + " " + formatConclusion(conclusion));
     }
 
-    public static void simplificationInput(Predicate predicate) {
+    /**
+     * Print the simplifier input and output side by side. This keeps the raw expression visible in debug traces while
+     * callers continue using the simplified expression for user-facing diagnostics.
+     */
+    public static void simplification(Expression input, Expression output) {
         if (!enabled()) {
             return;
         }
-        System.out.println(SMT_TAG + " unsimplified: " + predicate);
+        System.out.println(SMP_TAG + " Simplified " + Colors.CYAN + input + Colors.RESET + " to " + Colors.YELLOW
+                + output + Colors.RESET);
     }
 
-    public static void counterexampleAssignments(Counterexample counterexample) {
+    /**
+     * Print every assignment returned by the solver before error reporting filters the user-facing counterexample down
+     * to the variables mentioned in the diagnostic.
+     */
+    public static void counterexample(Counterexample counterexample) {
         if (!enabled() || counterexample == null || counterexample.assignments().isEmpty()) {
             return;
         }
-        System.out.println(SMT_TAG + " unfiltered counterexample assignments:");
-        for (var assignment : counterexample.assignments()) {
-            System.out.println(SMT_TAG + "     " + assignment.first() + " = " + assignment.second());
-        }
+        System.out
+                .println(SMP_TAG
+                        + " Counterexample: " + Colors.RED + counterexample.assignments().stream()
+                                .map(a -> a.first() + " = " + a.second()).collect(Collectors.joining(" && "))
+                        + Colors.RESET);
     }
 
     private static String plainLabel(VCImplication node) {
@@ -233,14 +246,14 @@ public final class DebugLog {
         if (!enabled()) {
             return;
         }
-        System.out.println(SMT_TAG + " result: " + Colors.GREEN + "UNSAT (subtype holds)" + Colors.RESET);
+        System.out.println(SMT_TAG + " Result: " + Colors.GREEN + "UNSAT (subtype holds)" + Colors.RESET);
     }
 
     public static void smtSat(Object counterexample) {
         if (!enabled()) {
             return;
         }
-        String header = SMT_TAG + " result: " + Colors.RED + "SAT (subtype fails)" + Colors.RESET;
+        String header = SMT_TAG + " Result: " + Colors.RED + "SAT (subtype fails)" + Colors.RESET;
         String pretty = formatCounterexample(counterexample);
         if (pretty == null) {
             System.out.println(header);
@@ -284,7 +297,7 @@ public final class DebugLog {
         if (!enabled()) {
             return;
         }
-        System.out.println(SMT_TAG + " result: " + Colors.YELLOW + "UNKNOWN (treated as OK)" + Colors.RESET);
+        System.out.println(SMT_TAG + " Result: " + Colors.YELLOW + "UNKNOWN (treated as OK)" + Colors.RESET);
     }
 
     /**
@@ -310,7 +323,7 @@ public final class DebugLog {
         if (!enabled()) {
             return;
         }
-        System.out.println(SMT_TAG + " result: " + Colors.RED + "ERROR" + Colors.RESET + " — "
+        System.out.println(SMT_TAG + " Result: " + Colors.RED + "ERROR" + Colors.RESET + " — "
                 + (message == null ? "(no message)" : message));
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
@@ -9,6 +9,7 @@ import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.ast.BinaryExpression;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.GroupExpression;
+import liquidjava.smt.Counterexample;
 import liquidjava.utils.Utils;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.reference.CtTypeReference;
@@ -128,6 +129,16 @@ public final class DebugLog {
             return;
         }
         System.out.println(SMT_TAG + " unsimplified: " + predicate);
+    }
+
+    public static void counterexampleAssignments(Counterexample counterexample) {
+        if (!enabled() || counterexample == null || counterexample.assignments().isEmpty()) {
+            return;
+        }
+        System.out.println(SMT_TAG + " counterexample assignments:");
+        for (var assignment : counterexample.assignments()) {
+            System.out.println(SMT_TAG + "     " + assignment.first() + " = " + assignment.second());
+        }
     }
 
     private static String plainLabel(VCImplication node) {

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/DebugLog.java
@@ -123,6 +123,13 @@ public final class DebugLog {
         System.out.println(SMT_TAG + " " + formatConclusion(conclusion));
     }
 
+    public static void simplificationInput(Predicate predicate) {
+        if (!enabled()) {
+            return;
+        }
+        System.out.println(SMT_TAG + " unsimplified: " + predicate);
+    }
+
     private static String plainLabel(VCImplication node) {
         return node.getName() + " : " + simpleType(node.getType());
     }

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import liquidjava.api.CommandLineLauncher;
+import liquidjava.diagnostics.DebugLog;
 import liquidjava.diagnostics.TranslationTable;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.formatter.VariableFormatter;
@@ -44,6 +44,8 @@ public class RefinementError extends LJError {
         if (counterexample == null || counterexample.assignments().isEmpty())
             return null;
 
+        DebugLog.counterexampleAssignments(counterexample);
+
         List<String> foundVarNames = new ArrayList<>();
         found.getValue().getVariableNames(foundVarNames);
         // also keep resolved static-final constants (e.g. Integer.MAX_VALUE) referenced by either side of the
@@ -53,8 +55,8 @@ public class RefinementError extends LJError {
         List<String> foundAssignments = found.getValue().getConjuncts().stream().map(Expression::toString).toList();
         String counterexampleString = counterexample.assignments().stream()
                 // only include variables that appear in the found value and are not already fixed there
-                .filter(a -> CommandLineLauncher.cmdArgs.debugMode || (foundVarNames.contains(a.first())
-                        && !foundAssignments.contains(a.first() + " == " + a.second())))
+                .filter(a -> foundVarNames.contains(a.first())
+                        && !foundAssignments.contains(a.first() + " == " + a.second()))
                 // format as "var == value"
                 .map(a -> VariableFormatter.format(a.first()) + " == " + a.second())
                 // join with "&&"

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import liquidjava.diagnostics.DebugLog;
 import liquidjava.diagnostics.TranslationTable;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.formatter.VariableFormatter;
@@ -43,8 +42,6 @@ public class RefinementError extends LJError {
     public String getCounterExampleString() {
         if (counterexample == null || counterexample.assignments().isEmpty())
             return null;
-
-        DebugLog.counterexample(counterexample);
 
         List<String> foundVarNames = new ArrayList<>();
         found.getValue().getVariableNames(foundVarNames);

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -44,7 +44,7 @@ public class RefinementError extends LJError {
         if (counterexample == null || counterexample.assignments().isEmpty())
             return null;
 
-        DebugLog.counterexampleAssignments(counterexample);
+        DebugLog.counterexample(counterexample);
 
         List<String> foundVarNames = new ArrayList<>();
         found.getValue().getVariableNames(foundVarNames);

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import liquidjava.api.CommandLineLauncher;
+import liquidjava.diagnostics.DebugLog;
 import liquidjava.diagnostics.errors.LJError;
 import liquidjava.diagnostics.errors.NotFoundError;
 import liquidjava.processor.context.AliasWrapper;
@@ -252,13 +252,12 @@ public class Predicate {
     }
 
     public ValDerivationNode simplify(Context context) {
+        DebugLog.simplificationInput(this);
+
         // collect aliases from context
         Map<String, AliasDTO> aliases = new HashMap<>();
         for (AliasWrapper aw : context.getAliases()) {
             aliases.put(aw.getName(), aw.createAliasDTO());
-        }
-        if (CommandLineLauncher.cmdArgs.debugMode) {
-            return new ValDerivationNode(exp.clone(), null);
         }
         // simplify expression
         return ExpressionSimplifier.simplify(exp.clone(), aliases);

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
@@ -252,15 +252,15 @@ public class Predicate {
     }
 
     public ValDerivationNode simplify(Context context) {
-        DebugLog.simplificationInput(this);
-
         // collect aliases from context
         Map<String, AliasDTO> aliases = new HashMap<>();
         for (AliasWrapper aw : context.getAliases()) {
             aliases.put(aw.getName(), aw.createAliasDTO());
         }
         // simplify expression
-        return ExpressionSimplifier.simplify(exp.clone(), aliases);
+        ValDerivationNode result = ExpressionSimplifier.simplify(exp.clone(), aliases);
+        DebugLog.simplification(this.getExpression(), result.getValue());
+        return result;
     }
 
     private static boolean isBooleanLiteral(Expression expr, boolean value) {


### PR DESCRIPTION
## Description
This PR makes it so instead of skipping the expression simplification in debug mode, it logs the unsimplified predicate and runs the simplification like normal. It also does the same for the counterexamples.

## Example

<img width="630" height="359" alt="image" src="https://github.com/user-attachments/assets/57b998f4-4b51-4e2b-b5ee-1e3e48a97568" />

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
