### PR TITLE
Add LSP Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ mvn exec:java -pl liquidjava-verifier -Dexec.mainClass="liquidjava.api.CommandLi
 
 If you're on Linux/macOS, you can use the `liquidjava` script (from the repository root) to simplify the process.
 
+The LiquidJava verifier can be run from the command line with the following options:
+
+| Option | Description |
+| --- | --- |
+| `<...paths>` | Paths (files or directories) to be verified by LiquidJava |
+| `-h`, `--help` | Show the help message with available options |
+| `-v`, `--version` | Show the current version of the verifier |
+| `-d`, `--debug` | Enable debug logging and skip expression simplification for troubleshooting |
+| `-lsp`, `--language-server` | Enable language server mode for editor support |
+
 **Test a correct case**:
 ```bash
 ./liquidjava liquidjava-example/src/main/java/testSuite/CorrectSimpleAssignment.java

--- a/liquidjava-verifier/src/main/java/liquidjava/api/CommandLineArgs.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/api/CommandLineArgs.java
@@ -22,6 +22,9 @@ public class CommandLineArgs {
     @Option(names = { "-d", "--debug" }, description = "Enable debug mode for more detailed output")
     public boolean debugMode;
 
+    @Option(names = { "-lsp", "--language-server" }, description = "Enable language server mode for editor support")
+    public boolean lspMode;
+
     @Parameters(arity = "1..*", paramLabel = "<...paths>", description = "Paths to be verified by LiquidJava")
     public List<String> paths;
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/ContextHistory.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/ContextHistory.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import liquidjava.api.CommandLineLauncher;
 import liquidjava.utils.Utils;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
@@ -44,6 +45,9 @@ public class ContextHistory {
     }
 
     public void saveContext(CtElement element, Context context) {
+        if (!CommandLineLauncher.cmdArgs.lspMode)
+            return;
+
         String file = Utils.getFile(element);
         if (file == null)
             return;


### PR DESCRIPTION
## Description
This PR adds the `-lsp` flag to skip the `ContextHistory` tracking in the CLI, which increases performance and decreases memory usage. This flag must be used in the language server.

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [x] Updated docs/README if behavior or API changed
