### PR TITLE
Fix Usage Detection for Repeated Equalities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,26 +7,38 @@ Thanks for your interest in contributing! This guide covers the essentials.
 - Java 20+
 - Maven 3.6+
 
-## Build & test
+## Build and Run
+
+To build the project, run:
 
 ```bash
-mvn clean install   # build everything
-mvn test            # run the test suite
+mvn clean install
 ```
 
-Run a single test:
+Code formatting runs automatically via `formatter-maven-plugin` during the `validate` phase.
 
-```bash
-mvn -pl liquidjava-verifier -Dtest=TestExamples#testMultiplePaths test
-```
-
-Verify a single file from the CLI:
+To verify a single file from the CLI, run:
 
 ```bash
 ./liquidjava path/to/File.java
 ```
 
-Code formatting runs automatically via `formatter-maven-plugin` during the `validate` phase.
+## Testing
+
+To run all tests, run:
+
+```bash
+mvn test
+```
+
+To run specific tests, run:
+
+```bash
+mvn -pl liquidjava-verifier -Dtest=ExpressionFormatterTest test
+mvn -pl liquidjava-verifier -Dtest=ExpressionSimplifierTest test
+mvn -pl liquidjava-verifier -Dtest=RefinementsParserTest test
+mvn -pl liquidjava-verifier -Dtest=VariableResolverTest test
+```
 
 ## Release
 

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
@@ -27,7 +27,7 @@ public class VariableResolver {
         resolveRecursive(exp, map);
 
         // remove variables that were not used in the expression
-        map.entrySet().removeIf(entry -> !hasUsage(exp, entry.getKey(), entry.getValue()));
+        map.entrySet().removeIf(entry -> !hasUsage(exp, entry.getKey(), entry.getValue(), true));
 
         // transitively resolve variables
         return resolveTransitive(map);
@@ -136,12 +136,14 @@ public class VariableResolver {
      *
      * @param exp
      * @param name
+     * @param value
+     * @param canExcludeDefinition
      *
      * @return true if used, false otherwise
      */
-    private static boolean hasUsage(Expression exp, String name, Expression value) {
+    private static boolean hasUsage(Expression exp, String name, Expression value, boolean canExcludeDefinition) {
         // exclude own definitions
-        if (exp instanceof BinaryExpression binary && "==".equals(binary.getOperator())) {
+        if (canExcludeDefinition && exp instanceof BinaryExpression binary && "==".equals(binary.getOperator())) {
             Expression left = binary.getFirstOperand();
             Expression right = binary.getSecondOperand();
             if (left instanceof Var v && v.getName().equals(name) && right.equals(value)
@@ -167,8 +169,10 @@ public class VariableResolver {
 
         // recurse children
         if (exp.hasChildren()) {
+            boolean childCanExcludeDefinition = exp instanceof BinaryExpression binary
+                    && "&&".equals(binary.getOperator());
             for (Expression child : exp.getChildren())
-                if (hasUsage(child, name, value))
+                if (hasUsage(child, name, value, childCanExcludeDefinition))
                     return true;
         }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
@@ -137,46 +137,34 @@ public class VariableResolver {
      * @param exp
      * @param name
      * @param value
-     * @param canExcludeDefinition
+     * @param topLevel
      *
      * @return true if used, false otherwise
      */
-    private static boolean hasUsage(Expression exp, String name, Expression value, boolean canExcludeDefinition) {
-        // exclude own definitions
-        if (canExcludeDefinition && exp instanceof BinaryExpression binary && "==".equals(binary.getOperator())) {
+    private static boolean hasUsage(Expression exp, String name, Expression value, boolean topLevel) {
+        if (topLevel && exp instanceof BinaryExpression binary && "&&".equals(binary.getOperator())) {
+            return hasUsage(binary.getFirstOperand(), name, value, true)
+                    || hasUsage(binary.getSecondOperand(), name, value, true);
+        }
+
+        if (topLevel && exp instanceof BinaryExpression binary && "==".equals(binary.getOperator())) {
             Expression left = binary.getFirstOperand();
             Expression right = binary.getSecondOperand();
-            if (left instanceof Var v && v.getName().equals(name) && right.equals(value)
-                    && (isConstant(right) || (!(right instanceof Var) && canSubstitute(v, right))))
-                return false;
-            if (left instanceof FunctionInvocation && left.toString().equals(name) && right.equals(value)
-                    && (isConstant(right) || (!(right instanceof Var) && !containsExpression(right, left))))
-                return false;
-            if (right instanceof Var v && v.getName().equals(name) && left.equals(value) && isConstant(left))
-                return false;
-            if (right instanceof FunctionInvocation && right.toString().equals(name) && left.equals(value)
-                    && isConstant(left))
+            boolean leftDefinition = name.equals(substitutionKey(left)) && right.equals(value)
+                    && (isConstant(right)
+                            || (left instanceof Var v && !(right instanceof Var) && canSubstitute(v, right))
+                            || (left instanceof FunctionInvocation && !(right instanceof Var)
+                                    && !containsExpression(right, left)));
+            boolean rightDefinition = name.equals(substitutionKey(right)) && left.equals(value) && isConstant(left);
+            if (leftDefinition || rightDefinition)
                 return false;
         }
 
-        // usage found
-        if (exp instanceof Var var && var.getName().equals(name)) {
+        if (name.equals(substitutionKey(exp)))
             return true;
-        }
-        if (exp instanceof FunctionInvocation && exp.toString().equals(name)) {
-            return true;
-        }
-
-        // recurse children
-        if (exp.hasChildren()) {
-            boolean childCanExcludeDefinition = exp instanceof BinaryExpression binary
-                    && "&&".equals(binary.getOperator());
-            for (Expression child : exp.getChildren())
-                if (hasUsage(child, name, value, childCanExcludeDefinition))
-                    return true;
-        }
-
-        // usage not found
+        for (Expression child : exp.getChildren())
+            if (hasUsage(child, name, value, false))
+                return true;
         return false;
     }
 

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -658,4 +658,12 @@ class ExpressionSimplifierTest {
 
         assertEquals("start(param)", result.getValue().toString());
     }
+
+    @Test
+    void testRepeatedEqualDefinitionPropagatesIntoTernaryCondition() {
+        Expression expression = parse("mode == 2 && (mode == 2 ? explicit(param) : start(param))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("explicit(param)", result.getValue().toString());
+    }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -666,4 +666,37 @@ class ExpressionSimplifierTest {
 
         assertEquals("explicit(param)", result.getValue().toString());
     }
+
+    @Test
+    void testRepeatedEqualDefinitionsPropagateIntoCompoundTernaryCondition() {
+        Expression expression = parse(
+                "mode == 2 && other == 5 && ((mode == 2 && other == 5) ? explicit(param) : start(param))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("explicit(param)", result.getValue().toString());
+    }
+
+    @Test
+    void testRepeatedEqualDefinitionPropagatesWhenUsageComesFirst() {
+        Expression expression = parse("(mode == 2 ? explicit(param) : start(param)) && mode == 2");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("explicit(param)", result.getValue().toString());
+    }
+
+    @Test
+    void testRepeatedEqualDefinitionsPropagateIntoNestedTernaryConditions() {
+        Expression expression = parse("mode == 2 && other == 3 && (mode == 2 ? (other == 3 ? a(p) : b(p)) : c(p))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("a(p)", result.getValue().toString());
+    }
+
+    @Test
+    void testRepeatedEqualDefinitionsPropagateIntoNestedTernaryElseBranch() {
+        Expression expression = parse("mode == 2 && other == 4 && (mode == 2 ? (other == 3 ? a(p) : b(p)) : c(p))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("b(p)", result.getValue().toString());
+    }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -685,6 +685,14 @@ class ExpressionSimplifierTest {
     }
 
     @Test
+    void testRepeatedFunctionInvocationDefinitionPropagatesIntoTernaryCondition() {
+        Expression expression = parse("modeOf(param) == 2 && (modeOf(param) == 2 ? explicit(param) : start(param))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expression);
+
+        assertEquals("explicit(param)", result.getValue().toString());
+    }
+
+    @Test
     void testRepeatedEqualDefinitionsPropagateIntoNestedTernaryConditions() {
         Expression expression = parse("mode == 2 && other == 3 && (mode == 2 ? (other == 3 ? a(p) : b(p)) : c(p))");
         ValDerivationNode result = ExpressionSimplifier.simplify(expression);

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
@@ -109,6 +109,26 @@ class VariableResolverTest {
     }
 
     @Test
+    void testRepeatedEqualDefinitionsInCompoundIteConditionCountAsUsage() {
+        Expression expression = parse(
+                "mode == 2 && other == 5 && ((mode == 2 && other == 5) ? explicit(param) : start(param))");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(2, result.size(), "Compound ternary condition should count as a use of both variables");
+        assertEquals("2", result.get("mode").toString());
+        assertEquals("5", result.get("other").toString());
+    }
+
+    @Test
+    void testRepeatedEqualDefinitionCountsAsUsageBeforeDefinitionConjunct() {
+        Expression expression = parse("(mode == 2 ? explicit(param) : start(param)) && mode == 2");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(1, result.size(), "Conjunct order should not affect repeated equality usage detection");
+        assertEquals("2", result.get("mode").toString());
+    }
+
+    @Test
     void testReturnVariableIsNotSubstituted() {
         Expression expression = parse("x > 0 && #ret_1 == x");
         Map<String, Expression> result = VariableResolver.resolve(expression);

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
@@ -129,6 +129,32 @@ class VariableResolverTest {
     }
 
     @Test
+    void testRepeatedFunctionInvocationDefinitionCountsAsUsage() {
+        Expression expression = parse("modeOf(param) == 2 && (modeOf(param) == 2 ? explicit(param) : start(param))");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(1, result.size(), "Function invocation definition should count repeated nested equality as usage");
+        assertEquals("2", result.get("modeOf(param)").toString());
+    }
+
+    @Test
+    void testRepeatedExpressionDefinitionCountsAsUsage() {
+        Expression expression = parse("limit == max - 1 && (limit == max - 1 ? a(p) : b(p))");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(1, result.size(), "Expression definition should count repeated nested equality as usage");
+        assertEquals("max - 1", result.get("limit").toString());
+    }
+
+    @Test
+    void testRepeatedTopLevelDefinitionsOnlyDoNotCountAsUsage() {
+        Expression expression = parse("mode == 2 && mode == 2");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertTrue(result.isEmpty(), "Repeated top-level definitions alone should not count as usage");
+    }
+
+    @Test
     void testReturnVariableIsNotSubstituted() {
         Expression expression = parse("x > 0 && #ret_1 == x");
         Map<String, Expression> result = VariableResolver.resolve(expression);

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
@@ -100,6 +100,15 @@ class VariableResolverTest {
     }
 
     @Test
+    void testRepeatedEqualDefinitionCountsAsUsage() {
+        Expression expression = parse("mode == 2 && (mode == 2 ? explicit(param) : start(param))");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(1, result.size(), "Repeated equalities should keep one definition and treat the other as usage");
+        assertEquals("2", result.get("mode").toString());
+    }
+
+    @Test
     void testReturnVariableIsNotSubstituted() {
         Expression expression = parse("x > 0 && #ret_1 == x");
         Map<String, Expression> result = VariableResolver.resolve(expression);


### PR DESCRIPTION
## Description
This PR fixes the `VariableResolver.hasUsage` so a matching equality is only excluded as a definition when it appears in a definition under a conjunction. This means that repeated equalities inside nested expressions now count as usages, allowing substitutions to propagate and simplify correctly.

## Example

#### Before

Both `x == 1` count has definitions.

```java
x == 1 && (x == 1 ? a(y) : b(y)) // most simplified
```

#### After

The first one counts has a definition and the second one counts as an usage.

```java
a(y) // most simplified
```

## Related Issue
None.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests in `ExpressionSimplifierTests` and `VariableResolverTests`
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
