### PR TITLE
Save Refined Function Placement

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/RefinedFunction.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/RefinedFunction.java
@@ -12,6 +12,7 @@ public class RefinedFunction extends Refined {
     private String targetClass;
     private List<ObjectState> stateChange;
     private String signature;
+    private PlacementInCode placementInCode;
 
     public RefinedFunction() {
         argRefinements = new ArrayList<>();
@@ -48,6 +49,14 @@ public class RefinedFunction extends Refined {
 
     public String getSignature() {
         return signature;
+    }
+
+    public void setPlacementInCode(CtElement element) {
+        placementInCode = PlacementInCode.createPlacement(element);
+    }
+
+    public PlacementInCode getPlacementInCode() {
+        return placementInCode;
     }
 
     public Predicate getRenamedRefinements(Context c, CtElement element) {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
@@ -43,6 +43,7 @@ public class MethodsFunctionsChecker {
         RefinedFunction f = new RefinedFunction();
         f.setName(c.getSimpleName());
         f.setType(c.getType());
+        f.setPlacementInCode(c);
         handleFunctionRefinements(f, c, c.getParameters());
         f.setRefReturn(new Predicate());
         CtTypeReference<?> declaring = c.getDeclaringType() != null ? c.getDeclaringType().getReference() : null;
@@ -79,6 +80,7 @@ public class MethodsFunctionsChecker {
         f.setName(method.getSimpleName().replaceAll("\\p{C}", "")); // remove any empty chars from string
         f.setType(method.getType());
         f.setRefReturn(new Predicate());
+        f.setPlacementInCode(method);
 
         CtClass<?> klass = null;
         if (method.getParent() instanceof CtClass) {
@@ -116,6 +118,7 @@ public class MethodsFunctionsChecker {
         f.setName(functionName.replaceAll("\\p{C}", "")); // remove any empty chars from string
         f.setType(method.getType());
         f.setRefReturn(new Predicate());
+        f.setPlacementInCode(method);
         f.setClass(prefix);
         f.setSignature(String.format("%s.%s", prefix, method.getSignature()));
         rtc.getContext().addFunctionToContext(f);


### PR DESCRIPTION
This PR allows the extension to go to a refined method definition by saving their position in the context history ([#80](https://github.com/liquid-java/vscode-liquidjava/pull/80)).
