### PR TITLE
Fix External Method Not Found

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/warnings/ExternalMethodNotFoundWarning.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/warnings/ExternalMethodNotFoundWarning.java
@@ -9,20 +9,20 @@ import spoon.reflect.cu.SourcePosition;
  */
 public class ExternalMethodNotFoundWarning extends LJWarning {
 
-    private final String methodName;
+    private final String signature;
     private final String className;
     private final String[] overloads;
 
-    public ExternalMethodNotFoundWarning(SourcePosition position, String message, String methodName, String className,
+    public ExternalMethodNotFoundWarning(SourcePosition position, String message, String signature, String className,
             String[] overloads) {
         super(message, position);
-        this.methodName = methodName;
+        this.signature = signature;
         this.className = className;
         this.overloads = overloads;
     }
 
-    public String getMethodName() {
-        return methodName;
+    public String getSignature() {
+        return signature;
     }
 
     public String getClassName() {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
@@ -80,11 +80,11 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
             }
         } else {
             if (!methodExists(targetType, method)) {
-                String message = String.format("Could not find method '%s %s' for '%s'",
-                        method.getType().getSimpleName(), method.getSignature(), prefix);
+                String signature = String.format("%s %s", method.getType().getSimpleName(), method.getSignature());
+                String message = String.format("Could not find method '%s' for '%s'", signature, prefix);
                 String[] overloads = getOverloads(targetType, method);
-                diagnostics.add(new ExternalMethodNotFoundWarning(method.getPosition(), message, method.getSignature(),
-                        prefix, overloads));
+                diagnostics.add(
+                        new ExternalMethodNotFoundWarning(method.getPosition(), message, signature, prefix, overloads));
                 return;
             }
         }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
@@ -72,10 +72,10 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
         boolean isConstructor = method.getSimpleName().equals(targetType.getSimpleName());
         if (isConstructor) {
             if (!constructorExists(targetType, method)) {
-                String message = String.format("Could not find constructor '%s' for '%s'", method.getSignature(),
-                        prefix);
+                String signature = method.getSignature();
+                String message = String.format("Could not find constructor '%s' for '%s'", signature, prefix);
                 String[] overloads = getOverloads(targetType, method);
-                diagnostics.add(new ExternalMethodNotFoundWarning(method.getPosition(), message, method.getSignature(),
+                diagnostics.add(new ExternalMethodNotFoundWarning(method.getPosition(), message, signature,
                         prefix, overloads));
             }
         } else {


### PR DESCRIPTION
This PR fixes a small issue where we would store for example `add(java.lang.String)` instead of `boolean add(java.lang.String)` in the `ExternalMethodNotFoundWarning`.