### PR TITLE
Store Derivation Nodes in State Refinement Errors

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
@@ -1,7 +1,7 @@
 package liquidjava.diagnostics.errors;
 
 import liquidjava.diagnostics.TranslationTable;
-import liquidjava.rj_language.ast.Expression;
+import liquidjava.rj_language.opt.derivation_node.ValDerivationNode;
 import spoon.reflect.cu.SourcePosition;
 
 /**
@@ -11,23 +11,23 @@ import spoon.reflect.cu.SourcePosition;
  */
 public class StateRefinementError extends LJError {
 
-    private final String expected;
-    private final String found;
+    private final ValDerivationNode expected;
+    private final ValDerivationNode found;
 
-    public StateRefinementError(SourcePosition position, Expression expected, Expression found,
+    public StateRefinementError(SourcePosition position, ValDerivationNode expected, ValDerivationNode found,
             TranslationTable translationTable, String customMessage) {
-        super("State Refinement Error",
-                String.format("Expected state %s but found %s", expected.toDisplayString(), found.toDisplayString()),
-                position, translationTable, customMessage);
-        this.expected = expected.toDisplayString();
-        this.found = found.toDisplayString();
+        super("State Refinement Error", String.format("Expected state %s but found %s",
+                expected.getValue().toDisplayString(), found.getValue().toDisplayString()), position, translationTable,
+                customMessage);
+        this.expected = expected;
+        this.found = found;
     }
 
-    public String getExpected() {
+    public ValDerivationNode getExpected() {
         return expected;
     }
 
-    public String getFound() {
+    public ValDerivationNode getFound() {
         return found;
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
@@ -75,8 +75,8 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
                 String signature = method.getSignature();
                 String message = String.format("Could not find constructor '%s' for '%s'", signature, prefix);
                 String[] overloads = getOverloads(targetType, method);
-                diagnostics.add(new ExternalMethodNotFoundWarning(method.getPosition(), message, signature,
-                        prefix, overloads));
+                diagnostics.add(
+                        new ExternalMethodNotFoundWarning(method.getPosition(), message, signature, prefix, overloads));
             }
         } else {
             if (!methodExists(targetType, method)) {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -391,8 +391,8 @@ public class VCChecker {
         gatherVariables(found, lrv, mainVars);
         TranslationTable map = new TranslationTable();
         VCImplication foundState = joinPredicates(found, mainVars, lrv, map);
-        throw new StateRefinementError(position, expected.getExpression(),
-                foundState.toConjunctions().simplify(context).getValue(), map, customMessage);
+        throw new StateRefinementError(position, expected.simplify(context),
+                foundState.toConjunctions().simplify(context), map, customMessage);
     }
 
     protected void throwStateConflictError(SourcePosition position, Predicate expected) throws StateConflictError {


### PR DESCRIPTION
This PR makes state refinement errors store `ValDerivationNode` values for expected and found expressions, instead of a plain `String` to allow expanding expressions in state refinement errors in the extension.