### PR TITLE
Preserve Origins in Ternary Simplifications

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/ExpressionFolding.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/ExpressionFolding.java
@@ -235,10 +235,20 @@ public class ExpressionFolding {
      */
     private static ValDerivationNode foldIte(ValDerivationNode node) {
         Ite iteExp = (Ite) node.getValue();
+        DerivationNode parent = node.getOrigin();
 
-        ValDerivationNode condNode = fold(new ValDerivationNode(iteExp.getCondition(), null));
-        ValDerivationNode thenNode = fold(new ValDerivationNode(iteExp.getThen(), null));
-        ValDerivationNode elseNode = fold(new ValDerivationNode(iteExp.getElse(), null));
+        ValDerivationNode condNode;
+        ValDerivationNode thenNode;
+        ValDerivationNode elseNode;
+        if (parent instanceof IteDerivationNode iteOrigin) {
+            condNode = fold(iteOrigin.getCondition());
+            thenNode = fold(iteOrigin.getThenBranch());
+            elseNode = fold(iteOrigin.getElseBranch());
+        } else {
+            condNode = fold(new ValDerivationNode(iteExp.getCondition(), null));
+            thenNode = fold(new ValDerivationNode(iteExp.getThen(), null));
+            elseNode = fold(new ValDerivationNode(iteExp.getElse(), null));
+        }
 
         Expression condition = condNode.getValue();
         Expression thenExp = thenNode.getValue();

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
@@ -4,6 +4,8 @@ import liquidjava.rj_language.ast.BinaryExpression;
 import liquidjava.rj_language.ast.Enum;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.FunctionInvocation;
+import liquidjava.rj_language.ast.GroupExpression;
+import liquidjava.rj_language.ast.Ite;
 import liquidjava.rj_language.ast.UnaryExpression;
 import liquidjava.rj_language.ast.Var;
 import liquidjava.rj_language.opt.derivation_node.BinaryDerivationNode;
@@ -99,6 +101,28 @@ public class VariablePropagation {
             return (left.getOrigin() != null || right.getOrigin() != null)
                     ? new ValDerivationNode(cloned, new BinaryDerivationNode(left, right, cloned.getOperator()))
                     : new ValDerivationNode(cloned, null);
+        }
+
+        // lift ternary origin
+        if (exp instanceof Ite ite) {
+            ValDerivationNode condition = propagateRecursive(ite.getCondition(), subs, varOrigins);
+            ValDerivationNode thenBranch = propagateRecursive(ite.getThen(), subs, varOrigins);
+            ValDerivationNode elseBranch = propagateRecursive(ite.getElse(), subs, varOrigins);
+            Ite cloned = (Ite) ite.clone();
+            cloned.setChild(0, condition.getValue());
+            cloned.setChild(1, thenBranch.getValue());
+            cloned.setChild(2, elseBranch.getValue());
+
+            return (condition.getOrigin() != null || thenBranch.getOrigin() != null || elseBranch.getOrigin() != null)
+                    ? new ValDerivationNode(cloned, new IteDerivationNode(condition, thenBranch, elseBranch))
+                    : new ValDerivationNode(cloned, null);
+        }
+
+        if (exp instanceof GroupExpression group && group.getChildren().size() == 1) {
+            ValDerivationNode child = propagateRecursive(group.getExpression(), subs, varOrigins);
+            GroupExpression cloned = (GroupExpression) group.clone();
+            cloned.setChild(0, child.getValue());
+            return new ValDerivationNode(cloned, child.getOrigin());
         }
 
         // recursively propagate children

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/ExpressionSimplifierTest.java
@@ -468,6 +468,22 @@ class ExpressionSimplifierTest {
     }
 
     @Test
+    void testIteConditionKeepsPropagatedVariableOrigin() {
+        Expression expr = parse("mode == 1 && (mode == 2 ? explicit(param) : start(param))");
+        ValDerivationNode result = ExpressionSimplifier.simplify(expr);
+
+        assertNotNull(result.getOrigin(), "ITE simplification should record the selected branch");
+        IteDerivationNode iteOrigin = (IteDerivationNode) result.getOrigin();
+        ValDerivationNode condition = iteOrigin.getCondition();
+        BinaryDerivationNode equality = (BinaryDerivationNode) condition.getOrigin();
+        ValDerivationNode left = equality.getLeft();
+
+        assertEquals("1", left.getValue().toString());
+        assertDerivationEquals(new VarDerivationNode("mode"), left.getOrigin(),
+                "Propagated condition value should come from the mode parameter");
+    }
+
+    @Test
     void testByteAliasExpansion() {
         String sut = "Byte(b)";
         AliasDTO byteAlias = new AliasDTO("Byte", List.of("int"), List.of("b"), "b >= -128 && b <= 127");


### PR DESCRIPTION
## Description
This PR fixes a debug in the simplification of ternary predicates. Previously, variable propagation substituted values inside ite and parenthesized group expression nodes but dropped the child origin tree, and `foldIte` then folded the ternary condition without that origin. As a result, some origins were not shown in the derivation tree.

## Example

```java
@StateRefinement(
to ="mode == ImageWriteParam.MODE_EXPLICIT ?
     compressionExplicit(this) :
     startCompression(this)"
)
void setCompressionMode(int mode);
```

#### Before

```json
{
  "value": "startCompression(param³³)",
  "origin": {
    "condition": {
      "value": false,
      "origin": {
        "op": "==",
        "left": {
          "value": 1,
          "origin": {
            "value": "ImageWriteParam.MODE_DEFAULT" // no origin
          }
        },
        "right": {
          "value": 2,
          "origin": {
            "value": "ImageWriteParam.MODE_EXPLICIT"
          }
        }
      }
    },
    "thenBranch": {
      "value": "compressionExplicit(param³³)"
    },
    "elseBranch": {
      "value": "startCompression(param³³)"
    }
  }
}
```

#### After

```json
{
  "value": "startCompression(param³³)",
  "origin": {
    "condition": {
      "value": false,
      "origin": {
        "op": "==",
        "left": {
          "value": 1,
          "origin": {
            "value": "ImageWriteParam.MODE_DEFAULT",
            "origin": {
              "var": "mode³²" // with origin
            }
          }
        },
        "right": {
          "value": 2,
          "origin": {
            "value": "ImageWriteParam.MODE_EXPLICIT"
          }
        }
      }
    },
    "thenBranch": {
      "value": "compressionExplicit(param³³)"
    },
    "elseBranch": {
      "value": "startCompression(param³³)"
    }
  }
}
```


## Related Issue
None.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests in `ExpressionSimplifierTest`
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
