### PR TITLE
Resolve bare #x / !#x conjuncts as boolean substitutions to trigger simplification

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariablePropagation.java
@@ -149,6 +149,18 @@ public class VariablePropagation {
             }
         }
 
+        // Mirror the resolver's bare-internal-var rule (`#x` ⇒ true, `!#x` ⇒ false): point #x's
+        // back-link at the conjunct that justified the substitution, so subsequent passes preserve
+        // provenance through these substitutions too.
+        if (value instanceof Var var && var.getName().startsWith("#")) {
+            DerivationNode back = origin != null ? origin : node;
+            varOrigins.putIfAbsent(var.getName(), back);
+        } else if (value instanceof UnaryExpression u && "!".equals(u.getOp()) && u.getExpression()instanceof Var inner
+                && inner.getName().startsWith("#")) {
+            DerivationNode back = origin != null ? origin : node;
+            varOrigins.putIfAbsent(inner.getName(), back);
+        }
+
         // recursively process the origin tree
         if (origin instanceof BinaryDerivationNode binOrigin) {
             extractVarOrigins(binOrigin.getLeft(), varOrigins);

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VariableResolver.java
@@ -9,6 +9,8 @@ import liquidjava.rj_language.ast.BinaryExpression;
 import liquidjava.rj_language.ast.Enum;
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.FunctionInvocation;
+import liquidjava.rj_language.ast.LiteralBoolean;
+import liquidjava.rj_language.ast.UnaryExpression;
 import liquidjava.rj_language.ast.Var;
 
 public class VariableResolver {
@@ -40,6 +42,18 @@ public class VariableResolver {
      * @param map
      */
     private static void resolveRecursive(Expression exp, Map<String, Expression> map) {
+        // Internal-var conjuncts assert truth: `#x` ⇒ `#x → true`, `!#x` ⇒ `#x → false`. Restricted to
+        // internal vars so user-facing predicates like `x && x` still display as `x` instead of `true`.
+        if (exp instanceof Var var && isInternal(var)) {
+            map.putIfAbsent(var.getName(), new LiteralBoolean(true));
+            return;
+        }
+        if (exp instanceof UnaryExpression unary && "!".equals(unary.getOp())
+                && unary.getExpression()instanceof Var inner && isInternal(inner)) {
+            map.putIfAbsent(inner.getName(), new LiteralBoolean(false));
+            return;
+        }
+
         if (!(exp instanceof BinaryExpression be))
             return;
 

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VariableResolverTest.java
@@ -214,4 +214,33 @@ class VariableResolverTest {
 
         assertTrue(result.isEmpty(), "Function invocation definitions with no usage should be ignored");
     }
+
+    @Test
+    void testBareNegatedInternalVarSubstitutesFalse() {
+        Expression expression = parse("!#fresh_1 && #fresh_1 == #hasNext_2");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(1, result.size(), "Should extract only the bare-conjunct substitution");
+        assertEquals("false", result.get("#fresh_1").toString(),
+                "!#fresh_1 as top-level conjunct should bind #fresh_1 to false");
+    }
+
+    @Test
+    void testBareInternalVarSubstitutesTrue() {
+        Expression expression = parse("#fresh_1 && #fresh_1 == #hasNext_2");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertEquals(1, result.size(), "Should extract only the bare-conjunct substitution");
+        assertEquals("true", result.get("#fresh_1").toString(),
+                "Bare #fresh_1 as top-level conjunct should bind #fresh_1 to true");
+    }
+
+    @Test
+    void testBareUserVarNotSubstituted() {
+        Expression expression = parse("x && y == x");
+        Map<String, Expression> result = VariableResolver.resolve(expression);
+
+        assertTrue(result.isEmpty(),
+                "Bare user-facing variables should not be substituted, to preserve their names in error messages");
+    }
 }


### PR DESCRIPTION
## Description
Simplification was not triggered for conjunctions without literals like `!hasNext`, so we've added a step to resolve the variables to their boolean values.

## Example
The error messages would not simplify, so:
Before:
```
State Refinement Error: Expected state hasNextElem(it³¹) but found 
(hasNext³⁰ ? hasNextElem(it³¹) : empty(it³¹)) && index(it³¹) == 0 && size(it³¹) == 5 && maybeEmpty(it²⁸) && false == hasNext¹⁶ && !#fresh³² && #fresh³² == hasNext³⁰
45 |         while (true){
46 |             if(!it.hasNext()){
47 |                 sum += it.next(); // State Refinement Error
   |                        ^^^^^^^^^
48 |             } else {
49 |                 break;

```

Now:
```
State Refinement Error: Expected state hasNextElem(it³¹) but found 
empty(it³¹) && index(it³¹) == 0 && size(it³¹) == 5 && maybeEmpty(it²⁸) && false == hasNext¹⁶
45 |         while (true){
46 |             if(!it.hasNext()){
47 |                 sum += it.next(); // State Refinement Error
   |                        ^^^^^^^^^
48 |             } else {
49 |                 break;

```

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
