### PR TITLE
Initialize Unknown States

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/classes/input_stream_reader_no_constructor_correct/InputStreamReaderRefinements.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/input_stream_reader_no_constructor_correct/InputStreamReaderRefinements.java
@@ -1,0 +1,15 @@
+package testSuite.classes.input_stream_reader_no_constructor_correct;
+
+import liquidjava.specification.*;
+
+// https://docs.oracle.com/javase/7/docs/api/java/io/InputStreamReader.html
+@ExternalRefinementsFor("java.io.InputStreamReader")
+@StateSet({"open", "closed"})
+public interface InputStreamReaderRefinements {
+
+    @StateRefinement(from="open(this)")
+    public int read();
+
+    @StateRefinement(from="open(this)", to="closed(this)")
+    public void close();
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/input_stream_reader_no_constructor_correct/SimpleTest.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/input_stream_reader_no_constructor_correct/SimpleTest.java
@@ -1,0 +1,13 @@
+package testSuite.classes.input_stream_reader_no_constructor_correct;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class SimpleTest {
+
+    public static void main(String[] args) throws IOException {
+        InputStreamReader isr = new InputStreamReader(System.in);
+        isr.read();
+        isr.close();
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/jpeg_correct/CompressImage.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/jpeg_correct/CompressImage.java
@@ -1,0 +1,33 @@
+package testSuite.classes.jpeg_correct;
+
+import java.io.*;
+import java.util.*;
+import javax.imageio.*;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.image.RenderedImage;
+
+public class CompressImage {
+
+    //  Adapted from https://stackoverflow.com/questions/72024965/how-to-compress-jpg-and-png-images-in-java
+    public String compressImage(File multipartFile, RenderedImage image) throws IOException {
+        String filePath = System.getProperty("java.io.tmpdir");
+        File compressedImageFile = new File(filePath);
+        OutputStream os = new FileOutputStream(compressedImageFile.getName());
+        String extension = multipartFile.getName().substring(multipartFile.getName().lastIndexOf('.') + 1);
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName(extension);
+        ImageWriter writer = writers.next();
+        ImageOutputStream ios = ImageIO.createImageOutputStream(os);
+        writer.setOutput(ios);
+
+        ImageWriteParam param = writer.getDefaultWriteParam(); // should initialize state to start()
+        if (param.canWriteCompressed()) {
+            param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            param.setCompressionQuality(0.5f);
+        }
+        writer.write(null, new IIOImage(image, null, null), param);
+        os.close();
+        ios.close();
+        writer.dispose();
+        return String.valueOf(compressedImageFile);
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/jpeg_correct/ImageWriteParamsRefinements.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/jpeg_correct/ImageWriteParamsRefinements.java
@@ -1,0 +1,39 @@
+package testSuite.classes.jpeg_correct;
+
+import liquidjava.specification.*;
+import java.util.Locale;
+import javax.imageio.ImageWriteParam;
+
+@SuppressWarnings("unused")
+@ExternalRefinementsFor("javax.imageio.ImageWriteParam")
+@StateSet({"start", "acceptCompression", "compressionExplicit", "compressionSet"})
+@RefinementAlias("Ratio(float v) { 0 <= v && v <= 1.0 }")
+public interface ImageWriteParamsRefinements {
+
+    @StateRefinement(to="start()")
+    void ImageWriteParam(Locale locale);
+
+    void setProgressiveMode(
+        @Refinement("mode == ImageWriteParam.MODE_DISABLED || mode == ImageWriteParam.MODE_DEFAULT || mode == ImageWriteParam.MODE_COPY_FROM_METADATA")
+        int mode
+    );
+
+    @StateRefinement(
+        from="compressionExplicit() || compressionSet()", 
+        to="mode == ImageWriteParam.MODE_EXPLICIT ? compressionExplicit() : start()"
+    )
+    @StateRefinement(
+        from="acceptCompression()", 
+        to="mode == ImageWriteParam.MODE_EXPLICIT ? compressionExplicit() : acceptCompression()"
+    )
+    void setCompressionMode(int mode);
+
+    @StateRefinement(from="compressionExplicit() || compressionSet()")
+    void setCompressionQuality(@Refinement("Ratio(_)") float quality);
+
+    @StateRefinement(from="start()", to="_ ? acceptCompression(this) : start()")
+    @StateRefinement(from="!start()")
+    boolean canWriteCompressed();
+
+    // ...
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
@@ -16,6 +16,7 @@ import liquidjava.processor.context.GhostState;
 import liquidjava.processor.context.RefinedVariable;
 import liquidjava.processor.facade.AliasDTO;
 import liquidjava.processor.facade.GhostDTO;
+import liquidjava.processor.refinement_checker.object_checkers.AuxStateHandler;
 import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.parsing.RefinementsParser;
 import liquidjava.smt.SMTEvaluator;
@@ -346,6 +347,7 @@ public abstract class TypeChecker extends CtScanner {
         String newName = String.format(Formats.INSTANCE, simpleName, context.getCounter());
         Predicate correctNewRefinement = refinementFound.substituteVariable(Keys.WILDCARD, newName);
         correctNewRefinement = correctNewRefinement.substituteVariable(Keys.THIS, newName);
+        correctNewRefinement = setInitialStateIfUnknown(correctNewRefinement, type, newName);
         cEt = cEt.substituteVariable(simpleName, newName);
 
         // Substitute variable in verification
@@ -356,6 +358,12 @@ public abstract class TypeChecker extends CtScanner {
         String customMessage = getMessageFromAnnotation(variable).orElse(mainRV != null ? mainRV.getMessage() : null);
         checkSMT(cEt, usage, customMessage); // TODO CHANGE
         context.addRefinementToVariableInContext(simpleName, type, cet, usage);
+    }
+
+    private Predicate setInitialStateIfUnknown(Predicate refinement, CtTypeReference<?> type, String instanceName) {
+        if (type == null || !refinement.isBooleanTrue())
+            return refinement;
+        return AuxStateHandler.getDefaultState(this, type.getQualifiedName(), Predicate.createVar(instanceName));
     }
 
     public void checkSMT(Predicate expectedType, CtElement element) throws LJError {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
@@ -87,10 +87,16 @@ public class AuxStateHandler {
      * @param tc
      */
     public static void setDefaultState(RefinedFunction f, TypeChecker tc) {
-        String klass = f.getTargetClass();
-        Predicate[] s = { Predicate.createVar(Keys.THIS) };
+        ObjectState os = new ObjectState();
+        os.setTo(getDefaultState(tc, f.getTargetClass(), Predicate.createVar(Keys.THIS)));
+        List<ObjectState> los = new ArrayList<>();
+        los.add(os);
+        f.setAllStates(los);
+    }
+
+    public static Predicate getDefaultState(TypeChecker tc, String klass, Predicate target) {
         Predicate c = new Predicate();
-        List<GhostFunction> sets = getDifferentSets(tc, klass); // ??
+        List<GhostFunction> sets = getDifferentSets(tc, klass);
         for (GhostFunction sg : sets) {
             String retType = sg.getReturnType().toString();
             Predicate typePredicate = switch (retType) {
@@ -100,14 +106,11 @@ public class AuxStateHandler {
             case "double" -> Predicate.createLit("0.0", Types.DOUBLE);
             default -> throw new RuntimeException("Ghost not implemented for type " + retType);
             };
-            Predicate p = Predicate.createEquals(Predicate.createInvocation(sg.getQualifiedName(), s), typePredicate);
+            Predicate p = Predicate.createEquals(Predicate.createInvocation(sg.getQualifiedName(), target),
+                    typePredicate);
             c = Predicate.createConjunction(c, p);
         }
-        ObjectState os = new ObjectState();
-        os.setTo(c);
-        List<ObjectState> los = new ArrayList<>();
-        los.add(os);
-        f.setAllStates(los);
+        return c;
     }
 
     /**


### PR DESCRIPTION
## Description
This PR initializes object instances with their default typestate (first state from each state set) when their refinement is unknown (`true`).

This fixes cases we try to verify an object without an explicit constructor invocation.
Also, this also improves external refinement interfaces that do not declare a constructor method.
Previously, this was required:

> Constructors must always be present for typestate checking to work correctly, because they are the point where the initial state values are assigned. Otherwise, the initial values are not set and the verifier won’t be able to track the state of the object across method calls. [liquidjava-docs](https://liquid-java.github.io/liquidjava-docs/annotations/state-refinement/#state-initialization)

With this change, this is now optional.

## Examples

### No Explicit Constructor Call

```java
ImageWriteParam param = writer.getDefaultWriteParam(); // state1(this) == 0 (start)
if (param.canWriteCompressed()) {
    param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
    param.setCompressionQuality(0.5f);
}
```

Previously, `param.canWriteCompressed()` would fail because `param` had unknown state (`true`) and it required it to be in either `start()` or `!start()`, but each was checked separately since they are from different state refinements.
Now `param` is initialized with the default `start` state.

### No Explicit Constructor Declaration

```java
@ExternalRefinementsFor("java.io.InputStreamReader")
@StateSet({"open", "closed"})
public interface InputStreamReaderRefinements {

    // public void InputStreamReader(InputStream in);

    @StateRefinement(from = "open(this)")
    int read();

    @StateRefinement(from = "open(this)", to = "closed(this)")
    void close();

    public static void main(String[] args) throws IOException {
        InputStreamReader isr = new InputStreamReader(System.in); // state1(this) == 0 (open)
        isr.read();
        isr.close();
    }
}
```

Previously, `isr.read()` would fail because `isr` had unknown state (`true`). 
Now `isr` is initialized with the default `open` state.

## Related Issue
None.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Code refactoring

## Checklist
- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed