### PR TITLE
Allow interfaces to be also annotated with external refinements

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_correct/IteratorRefinements.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_correct/IteratorRefinements.java
@@ -1,0 +1,23 @@
+package testSuite.classes.iterator_interface_correct;
+
+import liquidjava.specification.ExternalRefinementsFor;
+import liquidjava.specification.StateRefinement;
+import liquidjava.specification.StateSet;
+
+/**
+ * External refinements for the JDK interface {@code java.util.Iterator}. Exercises {@code @ExternalRefinementsFor} on an
+ * interface target (not a concrete class) and a generic method ({@code N next()} vs the JDK's {@code E next()}).
+ */
+@StateSet({ "hasMore", "inNext", "notInNext" })
+@ExternalRefinementsFor("java.util.Iterator")
+public interface IteratorRefinements<N> {
+
+    @StateRefinement(to = "_ --> hasMore()")
+    boolean hasNext();
+
+    @StateRefinement(from = "hasMore()", to = "inNext()")
+    N next();
+
+    @StateRefinement(from = "inNext()", to = "notInNext()")
+    void remove();
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_correct/Test.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_correct/Test.java
@@ -1,0 +1,17 @@
+package testSuite.classes.iterator_interface_correct;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class Test {
+
+    public static void main(String[] args) {
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(new Object());
+        Iterator<Object> it = list.iterator();
+        if (it.hasNext()) {
+            it.next();
+            it.remove(); // valid: remove() after next()
+        }
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_error/IteratorRefinements.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_error/IteratorRefinements.java
@@ -1,0 +1,23 @@
+package testSuite.classes.iterator_interface_error;
+
+import liquidjava.specification.ExternalRefinementsFor;
+import liquidjava.specification.StateRefinement;
+import liquidjava.specification.StateSet;
+
+/**
+ * External refinements for the JDK interface {@code java.util.Iterator}. Exercises {@code @ExternalRefinementsFor} on an
+ * interface target (not a concrete class) and a generic method ({@code N next()} vs the JDK's {@code E next()}).
+ */
+@StateSet({ "hasMore", "inNext", "notInNext" })
+@ExternalRefinementsFor("java.util.Iterator")
+public interface IteratorRefinements<N> {
+
+    @StateRefinement(to = "_ --> hasMore()")
+    boolean hasNext();
+
+    @StateRefinement(from = "hasMore()", to = "inNext()")
+    N next();
+
+    @StateRefinement(from = "inNext()", to = "notInNext()")
+    void remove();
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_error/Test.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/iterator_interface_error/Test.java
@@ -1,0 +1,14 @@
+package testSuite.classes.iterator_interface_error;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class Test {
+
+    public static void main(String[] args) {
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(new Object());
+        Iterator<Object> it = list.iterator();
+        it.remove(); // State Refinement Error
+    }
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
@@ -24,6 +24,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 
 public class ExternalRefinementTypeChecker extends TypeChecker {
@@ -66,10 +67,13 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
 
     public <R> void visitCtMethod(CtMethod<R> method) {
         CtType<?> targetType = factory.Type().createReference(prefix).getTypeDeclaration();
-        if (!(targetType instanceof CtClass))
+        if (!(targetType instanceof CtClass) && !(targetType instanceof CtInterface))
             return;
 
-        boolean isConstructor = method.getSimpleName().equals(targetType.getSimpleName());
+        // Interfaces have no constructors; only a class can declare one, so the constructor-name shortcut
+        // (a refinement method named like the target type) only applies to class targets.
+        boolean isConstructor = targetType instanceof CtClass
+                && method.getSimpleName().equals(targetType.getSimpleName());
         if (isConstructor) {
             if (!constructorExists(targetType, method)) {
                 String signature = method.getSignature();
@@ -148,6 +152,12 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
 
         if (type1 == null || type2 == null)
             return false;
+
+        // Type variables (generics such as E, N, T) carry different names in the JDK type and in the refinement
+        // interface (e.g. Iterator's `E next()` vs a spec's `N next()`), so they never match by qualified name.
+        // Treat any two type-parameter references as compatible.
+        if (type1 instanceof CtTypeParameterReference && type2 instanceof CtTypeParameterReference)
+            return true;
 
         return type1.getQualifiedName().equals(type2.getQualifiedName());
     }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
@@ -153,13 +153,16 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
         if (type1 == null || type2 == null)
             return false;
 
-        // Type variables (generics such as E, N, T) carry different names in the JDK type and in the refinement
-        // interface (e.g. Iterator's `E next()` vs a spec's `N next()`), so they never match by qualified name.
-        // Treat any two type-parameter references as compatible.
-        if (type1 instanceof CtTypeParameterReference && type2 instanceof CtTypeParameterReference)
-            return true;
+        // Type variables (generics such as E, N, T) carry different names in the JDK type
+        if (type1 instanceof CtTypeParameterReference t1 && type2 instanceof CtTypeParameterReference t2)
+            return boundName(t1).equals(boundName(t2));
 
         return type1.getQualifiedName().equals(type2.getQualifiedName());
+    }
+
+    private static String boundName(CtTypeParameterReference ref) {
+        CtTypeReference<?> bound = ref.getBoundingType();
+        return bound == null ? "java.lang.Object" : bound.getQualifiedName();
     }
 
     private boolean parametersMatch(List<?> targetParams, List<?> refinementParams) {


### PR DESCRIPTION
## Description
Before, if we had interfaces as the external libraries that we were targeting, we would get no verification. 
Now we support that.


## Example
Ignored before, now its okay.
```java
@StateSet({ "hasMore", "inNext", "notInNext" })
@ExternalRefinementsFor("java.util.Iterator") // Iterator is an Interface
public interface IteratorRefinements<N> {
```

## Related Issue
[Reference any related issue]

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
