### PR TITLE
Fix VCImplication Ordering

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -290,8 +290,8 @@ public class VCChecker {
         }
         VCImplication cSMT = new VCImplication(new Predicate());
         if (firstSi != null) {
-            lastSi.setNext(new VCImplication(expectedType));
             cSMT = firstSi.clone();
+            lastSi.setNext(new VCImplication(expectedType));
         }
         return cSMT;
     }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -252,20 +252,6 @@ public class VCChecker {
 
         VCImplication firstSi = null;
         VCImplication lastSi = null;
-        // Check
-        for (RefinedVariable var : mainVars) { // join main refinements of mainVars
-            addMap(var, map);
-            VCImplication si = new VCImplication(var.getName(), var.getType(), var.getMainRefinement());
-            if (lastSi != null) {
-                lastSi.setNext(si);
-                lastSi = si;
-            }
-            if (firstSi == null) {
-                firstSi = si;
-                lastSi = si;
-            }
-        }
-
         for (RefinedVariable var : vars) { // join refinements of vars
             addMap(var, map);
 
@@ -289,10 +275,23 @@ public class VCChecker {
                 lastSi = si;
             }
         }
+
+        for (RefinedVariable var : mainVars) { // join main refinements of mainVars
+            addMap(var, map);
+            VCImplication si = new VCImplication(var.getName(), var.getType(), var.getMainRefinement());
+            if (lastSi != null) {
+                lastSi.setNext(si);
+                lastSi = si;
+            }
+            if (firstSi == null) {
+                firstSi = si;
+                lastSi = si;
+            }
+        }
         VCImplication cSMT = new VCImplication(new Predicate());
         if (firstSi != null) {
-            cSMT = firstSi.clone();
             lastSi.setNext(new VCImplication(expectedType));
+            cSMT = firstSi.clone();
         }
         return cSMT;
     }
@@ -331,6 +330,8 @@ public class VCChecker {
                 .filter(rv -> !allVars.contains(rv)).forEach(rv -> {
                     allVars.add(rv);
                     recAuxGetVars(rv, allVars);
+                    allVars.remove(rv);
+                    allVars.add(rv);
                 });
     }
 


### PR DESCRIPTION
## Description
This PR fixes VC implication construction order so each forall is introduced before it appears in the scope of another implication.

## Example

```java
int y = 5;
@Refinement("_ > 0")
int x = y;
```

### Before

```
∀#x_1:int. #x_1 == #y_0 =>
∀#y_0:int. #y_0 == 5
```

### After

```
∀#y_0:int. #y_0 == 5 =>
∀#x_1:int. #x_1 == #y_0
```

## Related Issue
None.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
