### PR TITLE
Get Refinements needs to visit the variable first

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_correct/ResultSetTests.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_correct/ResultSetTests.java
@@ -62,4 +62,19 @@ public class ResultSetTests {
             return 0.0f;
         }
     }
+
+    float readAverage2(Connection conn) throws SQLException {
+        Statement parentstmt = conn.createStatement();
+        ResultSet parentMessage =
+                parentstmt.executeQuery("SELECT SUM(IMPORTANCE) AS IMPAVG FROM MAIL");
+        // FIX (from accepted answer): parentMessage.next();
+        // VIOLATION: cursor is before the first row; getFloat() with no next().
+        boolean b = parentMessage.next();
+        if( b ) {
+            float avgsum = parentMessage.getFloat("IMPAVG");
+            return avgsum;
+        } else {
+            return 0.0f;
+        }
+    }
 }

--- a/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_correct/ResultSetTests.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_correct/ResultSetTests.java
@@ -63,12 +63,13 @@ public class ResultSetTests {
         }
     }
 
-    float readAverage2(Connection conn) throws SQLException {
+    float readAverageStoredCondition(Connection conn) throws SQLException {
         Statement parentstmt = conn.createStatement();
         ResultSet parentMessage =
                 parentstmt.executeQuery("SELECT SUM(IMPORTANCE) AS IMPAVG FROM MAIL");
-        // FIX (from accepted answer): parentMessage.next();
-        // VIOLATION: cursor is before the first row; getFloat() with no next().
+        // Regression for issue #241: next()'s result is stored in a boolean before the `if`.
+        // The transition (_ ? onRow : endRows) must still flow through `b`, so the guarded
+        // getFloat() is on a row (onRow) and verifies — exactly as the inline readAverage above.
         boolean b = parentMessage.next();
         if( b ) {
             float avgsum = parentMessage.getFloat("IMPAVG");

--- a/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_error/ResultSetTests.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_error/ResultSetTests.java
@@ -68,7 +68,18 @@ public class ResultSetTests {
         return avgsum;
     }
 
-        // Branch-sensitive: legal in the then-branch (onRow), illegal in the else-branch (endRows).
+    // Issue #241 soundness: storing next()'s result in a boolean must NOT make getFloat()
+    // unconditionally legal. With no guard the state is `next ? onRow : endRows`, so onRow is
+    // not guaranteed and getFloat() must still be rejected.
+    float readAverageStoredNoGuard(Connection conn) throws SQLException {
+        Statement parentstmt = conn.createStatement();
+        ResultSet parentMessage = parentstmt.executeQuery("SELECT SUM(IMPORTANCE) AS IMPAVG FROM MAIL");
+        boolean b = parentMessage.next();
+        float avgsum = parentMessage.getFloat("IMPAVG"); // State Refinement Error
+        return avgsum;
+    }
+
+    // Issue #241 branch-sensitivity: legal in the then-branch (onRow), illegal in the else-branch (endRows).
     float readAverageVarElse(Connection conn) throws SQLException {
         Statement parentstmt = conn.createStatement();
         ResultSet parentMessage = parentstmt.executeQuery("SELECT SUM(IMPORTANCE) AS IMPAVG FROM MAIL");

--- a/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_error/ResultSetTests.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/resultset_forward_error/ResultSetTests.java
@@ -67,4 +67,18 @@ public class ResultSetTests {
         float avgsum = parentMessage.getFloat("IMPAVG"); // State Refinement Error
         return avgsum;
     }
+
+        // Branch-sensitive: legal in the then-branch (onRow), illegal in the else-branch (endRows).
+    float readAverageVarElse(Connection conn) throws SQLException {
+        Statement parentstmt = conn.createStatement();
+        ResultSet parentMessage = parentstmt.executeQuery("SELECT SUM(IMPORTANCE) AS IMPAVG FROM MAIL");
+        float avgsum = 0.0f;
+        boolean b = parentMessage.next();
+        if (b) {
+            avgsum = parentMessage.getFloat("IMPAVG");
+        } else {
+            avgsum = parentMessage.getFloat("IMPAVG"); // State Refinement Error
+        }
+        return avgsum;
+    }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
@@ -321,6 +321,10 @@ public class RefinementTypeChecker extends TypeChecker {
     public <T> void visitCtVariableRead(CtVariableRead<T> variableRead) {
         super.visitCtVariableRead(variableRead);
         CtVariable<T> varDecl = variableRead.getVariable().getDeclaration();
+        // Some CtVariableRead forms have no resolvable declaration (e.g. accesses to symbols outside the
+        // model); with no name there is no context entry to attach, so leave the metadata as-is.
+        if (varDecl == null)
+            return;
         getPutVariableMetadata(variableRead, varDecl.getSimpleName());
     }
 
@@ -539,8 +543,15 @@ public class RefinementTypeChecker extends TypeChecker {
 
     private Predicate getExpressionRefinements(CtExpression<?> element) throws LJError {
         if (element instanceof CtFieldRead<?>) {
+            // CtFieldRead is a subtype of CtVariableRead and MUST be matched first: field reads (including
+            // the array pseudo-field `.length`, whose declaration is null) are handled by visitCtFieldRead
+            // during the surrounding scan, so here we just read the metadata it already set.
             return getRefinement(element);
         } else if (element instanceof CtVariableRead<?> varRead) {
+            // Visit the read so its metadata becomes `_ == <last instance>`, linking the variable to the
+            // instance that carries its refinement (e.g. a stored method result). Without this, `if (b)`
+            // looks refinement-free and is treated as uninformative, dropping the typestate that b's
+            // defining call established (#241).
             visitCtVariableRead(varRead);
             return getRefinement(element);
         } else if (element instanceof CtBinaryOperator<?>) {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
@@ -542,16 +542,10 @@ public class RefinementTypeChecker extends TypeChecker {
     }
 
     private Predicate getExpressionRefinements(CtExpression<?> element) throws LJError {
-        if (element instanceof CtFieldRead<?>) {
-            // CtFieldRead is a subtype of CtVariableRead and MUST be matched first: field reads (including
-            // the array pseudo-field `.length`, whose declaration is null) are handled by visitCtFieldRead
-            // during the surrounding scan, so here we just read the metadata it already set.
+        if (element instanceof CtFieldRead<?> fieldRead) {
+            visitCtFieldRead(fieldRead);
             return getRefinement(element);
         } else if (element instanceof CtVariableRead<?> varRead) {
-            // Visit the read so its metadata becomes `_ == <last instance>`, linking the variable to the
-            // instance that carries its refinement (e.g. a stored method result). Without this, `if (b)`
-            // looks refinement-free and is treated as uninformative, dropping the typestate that b's
-            // defining call established (#241).
             visitCtVariableRead(varRead);
             return getRefinement(element);
         } else if (element instanceof CtBinaryOperator<?>) {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
@@ -538,8 +538,10 @@ public class RefinementTypeChecker extends TypeChecker {
     }
 
     private Predicate getExpressionRefinements(CtExpression<?> element) throws LJError {
-        if (element instanceof CtVariableRead<?>) {
-            // CtVariableRead<?> elemVar = (CtVariableRead<?>) element;
+        if (element instanceof CtFieldRead<?>) {
+            return getRefinement(element);
+        } else if (element instanceof CtVariableRead<?> varRead) {
+            visitCtVariableRead(varRead);
             return getRefinement(element);
         } else if (element instanceof CtBinaryOperator<?>) {
             CtBinaryOperator<?> binop = (CtBinaryOperator<?>) element;


### PR DESCRIPTION
## Description
Closes #241 

## Example
Examples added
```java
   float readAverageStoredCondition(Connection conn) throws SQLException {
        Statement parentstmt = conn.createStatement();
        ResultSet parentMessage =
                parentstmt.executeQuery("SELECT SUM(IMPORTANCE) AS IMPAVG FROM MAIL");
        boolean b = parentMessage.next();
        if( b ) { // was not getting the correct refinement before
            float avgsum = parentMessage.getFloat("IMPAVG");
            return avgsum;
        } else {
            return 0.0f;
        }
    }
```

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
