### PR TITLE
Track Simplification Pass Names

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplification.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplification.java
@@ -50,6 +50,6 @@ public class VCSimplification {
         VCImplication simplified = pass.apply(implication.getImplication());
         if (implication.getImplication().equals(simplified))
             return implication;
-        return new VCSimplificationResult(simplified, implication);
+        return new VCSimplificationResult(simplified, implication, pass.getName());
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationPass.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationPass.java
@@ -9,8 +9,7 @@ public interface VCSimplificationPass {
     VCImplication apply(VCImplication implication);
 
     default String getName() {
-        String className = getClass().getSimpleName();
-        String name = className.startsWith("VC") ? className.substring(2) : className;
-        return name.replaceAll("(?<=[a-z0-9])(?=[A-Z])", " ");
+        return getClass().getSimpleName().replaceFirst("^VC", "").replaceFirst("Simplification$", "")
+                .replaceAll("(?<=[a-z0-9])(?=[A-Z])", " ");
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationPass.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationPass.java
@@ -7,4 +7,10 @@ import liquidjava.processor.VCImplication;
  */
 public interface VCSimplificationPass {
     VCImplication apply(VCImplication implication);
+
+    default String getName() {
+        String className = getClass().getSimpleName();
+        String name = className.startsWith("VC") ? className.substring(2) : className;
+        return name.replaceAll("(?<=[a-z0-9])(?=[A-Z])", " ");
+    }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
@@ -11,14 +11,18 @@ public final class VCSimplificationResult {
 
     private final VCImplication implication;
     private final VCSimplificationResult origin;
+    private final String simplification;
 
     public VCSimplificationResult(VCImplication implication) {
-        this(implication, null);
+        this.implication = Objects.requireNonNull(implication).clone();
+        this.origin = null;
+        this.simplification = null;
     }
 
-    public VCSimplificationResult(VCImplication implication, VCSimplificationResult origin) {
+    public VCSimplificationResult(VCImplication implication, VCSimplificationResult origin, String simplification) {
         this.implication = Objects.requireNonNull(implication).clone();
-        this.origin = origin;
+        this.origin = Objects.requireNonNull(origin);
+        this.simplification = Objects.requireNonNull(simplification);
     }
 
     /**
@@ -33,6 +37,13 @@ public final class VCSimplificationResult {
      */
     public VCSimplificationResult getOrigin() {
         return origin;
+    }
+
+    /**
+     * Returns the name of the simplification pass that produced this result or null for the original VC chain
+     */
+    public String getSimplification() {
+        return simplification;
     }
 
     @Override

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
@@ -14,15 +14,15 @@ public final class VCSimplificationResult {
     private final String simplification;
 
     public VCSimplificationResult(VCImplication implication) {
-        this.implication = Objects.requireNonNull(implication).clone();
+        this.implication = implication.clone();
         this.origin = null;
         this.simplification = null;
     }
 
     public VCSimplificationResult(VCImplication implication, VCSimplificationResult origin, String simplification) {
-        this.implication = Objects.requireNonNull(implication).clone();
-        this.origin = Objects.requireNonNull(origin);
-        this.simplification = Objects.requireNonNull(simplification);
+        this.implication = implication.clone();
+        this.origin = origin;
+        this.simplification = simplification;
     }
 
     /**


### PR DESCRIPTION
## Description
This PR makes each `VCSimplificationResult` save the name of the simplification that produced it, which is derived automatically through `VCSimplificationPass.getName()`. The VS Code extension can then display this information to make simplification results easier to understand.

## Example
```java
result.getSimplification(); // "Substitution" || "Folding" || "Arithmetic" || ...
```

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed