### PR TITLE
Filter & Sort Counterexamples by Binders

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/ErrorBoolean.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorBoolean.java
@@ -1,0 +1,11 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorBoolean {
+
+    @Refinement("_ == true")
+    boolean mustBeTrue(boolean value) {
+        return value; // Refinement Error
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorDependentRefinement.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorDependentRefinement.java
@@ -9,7 +9,7 @@ public class ErrorDependentRefinement {
         int smaller = 5;
         @Refinement("bigger > 20")
         int bigger = 50;
-        @Refinement("_ > smaller  && _ < bigger")
+        @Refinement("_ > smaller && _ < bigger")
         int middle = 21; // Refinement Error
     }
 }

--- a/liquidjava-example/src/main/java/testSuite/ErrorDependentUpperBound.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorDependentUpperBound.java
@@ -1,0 +1,13 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorDependentUpperBound {
+
+    @Refinement("0 <= _ && _ < len")
+    int nextIndex(
+            @Refinement("_ > 0") int len,
+            @Refinement("0 <= _ && _ < len") int i) {
+        return i + 1; // Refinement Error
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorIdentity.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorIdentity.java
@@ -1,0 +1,11 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorIdentity {
+
+    @Refinement("_ > 0")
+    int positiveIdentity(int x) {
+        return x; // Refinement Error
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorIntegerDivision.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorIntegerDivision.java
@@ -1,0 +1,11 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorIntegerDivision {
+
+    @Refinement("_ > 0")
+    int half(@Refinement("_ > 0") int x) {
+        return x / 2; // Refinement Error
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorLiteralZero.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorLiteralZero.java
@@ -1,0 +1,11 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorLiteralZero {
+
+    @Refinement("_ != 0")
+    int zero() {
+        return 0; // Refinement Error
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorRecursiveDecrement.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorRecursiveDecrement.java
@@ -1,0 +1,10 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorRecursiveDecrement {
+
+    public int f(@Refinement("_ > 0") int x) {
+        return f(x - 1); // Refinement Error
+    }
+}

--- a/liquidjava-verifier/pom.xml
+++ b/liquidjava-verifier/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>io.github.liquid-java</groupId>
 	<artifactId>liquidjava-verifier</artifactId>
-	<version>0.0.27</version>
+	<version>0.0.28</version>
 	<name>liquidjava-verifier</name>
 	<description>LiquidJava Verifier</description>
 	<url>https://github.com/liquid-java/liquidjava</url>

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 
 import liquidjava.diagnostics.TranslationTable;
 import liquidjava.rj_language.Predicate;
-import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.formatter.VariableFormatter;
 import liquidjava.rj_language.opt.VCSimplificationResult;
 import liquidjava.smt.Counterexample;
@@ -45,38 +44,30 @@ public class RefinementError extends LJError {
 
     @Override
     public String getDetails() {
-        String counterexampleString = getCounterExampleString();
-        if (counterexampleString == null)
+        Counterexample counterexamples = getCounterExamples();
+        if (counterexamples == null)
             return "";
+
+        String counterexampleString = counterexamples.assignments().stream()
+                .map(a -> VariableFormatter.format(a.first()) + " == " + a.second())
+                .collect(Collectors.joining(" && "));
         return "Counterexample: " + counterexampleString;
     }
 
-    public String getCounterExampleString() {
+    // Filters counterexample assignments only in found VC and sorts them in the order of its binders
+    public Counterexample getCounterExamples() {
         if (counterexample == null || counterexample.assignments().isEmpty())
             return null;
 
-        List<String> foundVarNames = new ArrayList<>();
-        Expression foundExpression = getFound().getImplication().toPredicate().getExpression();
-        Expression expectedExpression = expected.getExpression();
-        foundExpression.getVariableNames(foundVarNames);
-        // also keep resolved static-final constants (e.g. Integer.MAX_VALUE) referenced by either side of the
-        // subtyping check, so the counterexample maps the symbolic name back to its compile-time value
-        foundExpression.getResolvedConstantNames(foundVarNames);
-        expectedExpression.getResolvedConstantNames(foundVarNames);
-        List<String> foundAssignments = foundExpression.getConjuncts().stream().map(Expression::toString).toList();
-        String counterexampleString = counterexample.assignments().stream()
-                // only include variables that appear in the found value and are not already fixed there
-                .filter(a -> foundVarNames.contains(a.first())
-                        && !foundAssignments.contains(a.first() + " == " + a.second()))
-                // format as "var == value"
-                .map(a -> VariableFormatter.format(a.first()) + " == " + a.second())
-                // join with "&&"
-                .collect(Collectors.joining(" && "));
+        List<String> binderNames = getFound().getBinders();
+        var assignments = counterexample.assignments().stream().filter(a -> binderNames.contains(a.first()))
+                .sorted((a, b) -> Integer.compare(binderNames.indexOf(a.first()), binderNames.indexOf(b.first())))
+                .toList();
 
-        if (counterexampleString.isEmpty())
+        if (assignments.isEmpty())
             return null;
 
-        return counterexampleString;
+        return new Counterexample(assignments);
     }
 
     public Counterexample getCounterexample() {

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -1,11 +1,12 @@
 package liquidjava.diagnostics.errors;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import liquidjava.diagnostics.TranslationTable;
 import liquidjava.rj_language.Predicate;
+import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.formatter.VariableFormatter;
 import liquidjava.rj_language.opt.VCSimplificationResult;
 import liquidjava.smt.Counterexample;
@@ -60,7 +61,10 @@ public class RefinementError extends LJError {
             return null;
 
         List<String> binderNames = getFound().getBinders();
+        Set<String> knownAssignments = getFound().getImplication().toPredicate().getExpression().getConjuncts().stream()
+                .map(Expression::toString).collect(Collectors.toSet());
         var assignments = counterexample.assignments().stream().filter(a -> binderNames.contains(a.first()))
+                .filter(a -> !knownAssignments.contains(a.first() + " == " + a.second()))
                 .sorted((a, b) -> Integer.compare(binderNames.indexOf(a.first()), binderNames.indexOf(b.first())))
                 .toList();
 

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -46,7 +46,7 @@ public class RefinementError extends LJError {
 
     @Override
     public String getDetails() {
-        if (counterexample == null)
+        if (counterexample.isEmpty())
             return "";
 
         String counterexampleString = counterexample.assignments().stream()
@@ -69,9 +69,6 @@ public class RefinementError extends LJError {
 
     // Filters counterexample assignments only in found VC and sorts them in the order of its binders
     private Counterexample filterCounterexample(Counterexample counterexample) {
-        if (counterexample == null || counterexample.assignments().isEmpty())
-            return null;
-
         List<String> binderNames = getFound().getBinders();
         Set<String> knownAssignments = getFound().getImplication().toPredicate().getExpression().getConjuncts().stream()
                 .map(Expression::toString).collect(Collectors.toSet());
@@ -80,9 +77,6 @@ public class RefinementError extends LJError {
                 .filter(a -> !knownAssignments.contains(a.first() + " == " + a.second()))
                 .sorted((a, b) -> Integer.compare(binderNames.indexOf(a.first()), binderNames.indexOf(b.first())))
                 .toList();
-
-        if (assignments.isEmpty())
-            return null;
 
         return new Counterexample(assignments);
     }

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -10,6 +10,7 @@ import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.formatter.VariableFormatter;
 import liquidjava.rj_language.opt.VCSimplificationResult;
 import liquidjava.smt.Counterexample;
+import liquidjava.utils.Pair;
 import spoon.reflect.cu.SourcePosition;
 
 /**
@@ -34,7 +35,7 @@ public class RefinementError extends LJError {
                 position, translationTable, customMessage);
         this.expected = expected;
         this.found = found;
-        this.counterexample = counterexample;
+        this.counterexample = filterCounterexample(counterexample);
         this.declarationPosition = declarationPosition;
     }
 
@@ -45,33 +46,13 @@ public class RefinementError extends LJError {
 
     @Override
     public String getDetails() {
-        Counterexample counterexamples = getCounterExamples();
-        if (counterexamples == null)
+        if (counterexample == null)
             return "";
 
-        String counterexampleString = counterexamples.assignments().stream()
+        String counterexampleString = counterexample.assignments().stream()
                 .map(a -> VariableFormatter.format(a.first()) + " == " + a.second())
                 .collect(Collectors.joining(" && "));
         return "Counterexample: " + counterexampleString;
-    }
-
-    // Filters counterexample assignments only in found VC and sorts them in the order of its binders
-    public Counterexample getCounterExamples() {
-        if (counterexample == null || counterexample.assignments().isEmpty())
-            return null;
-
-        List<String> binderNames = getFound().getBinders();
-        Set<String> knownAssignments = getFound().getImplication().toPredicate().getExpression().getConjuncts().stream()
-                .map(Expression::toString).collect(Collectors.toSet());
-        var assignments = counterexample.assignments().stream().filter(a -> binderNames.contains(a.first()))
-                .filter(a -> !knownAssignments.contains(a.first() + " == " + a.second()))
-                .sorted((a, b) -> Integer.compare(binderNames.indexOf(a.first()), binderNames.indexOf(b.first())))
-                .toList();
-
-        if (assignments.isEmpty())
-            return null;
-
-        return new Counterexample(assignments);
     }
 
     public Counterexample getCounterexample() {
@@ -84,5 +65,25 @@ public class RefinementError extends LJError {
 
     public VCSimplificationResult getFound() {
         return found;
+    }
+
+    // Filters counterexample assignments only in found VC and sorts them in the order of its binders
+    private Counterexample filterCounterexample(Counterexample counterexample) {
+        if (counterexample == null || counterexample.assignments().isEmpty())
+            return null;
+
+        List<String> binderNames = getFound().getBinders();
+        Set<String> knownAssignments = getFound().getImplication().toPredicate().getExpression().getConjuncts().stream()
+                .map(Expression::toString).collect(Collectors.toSet());
+        List<Pair<String, String>> assignments = counterexample.assignments().stream()
+                .filter(a -> binderNames.contains(a.first()))
+                .filter(a -> !knownAssignments.contains(a.first() + " == " + a.second()))
+                .sorted((a, b) -> Integer.compare(binderNames.indexOf(a.first()), binderNames.indexOf(b.first())))
+                .toList();
+
+        if (assignments.isEmpty())
+            return null;
+
+        return new Counterexample(assignments);
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -23,7 +23,6 @@ import liquidjava.smt.SMTEvaluator;
 import liquidjava.smt.SMTResult;
 import liquidjava.utils.Utils;
 import liquidjava.utils.constants.Keys;
-import liquidjava.utils.Utils;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
@@ -1,5 +1,8 @@
 package liquidjava.rj_language.opt;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import liquidjava.processor.VCImplication;
 
 /**
@@ -42,6 +45,17 @@ public final class VCSimplificationResult {
      */
     public String getSimplification() {
         return simplification;
+    }
+
+    /**
+     * Returns the list of binder names in the simplified VC chain in order of appearance
+     */
+    public List<String> getBinders() {
+        ArrayList<String> binderNames = new ArrayList<>();
+        for (VCImplication current = getImplication(); current != null; current = current.getNext())
+            if (current.hasBinder())
+                binderNames.add(current.getName());
+        return binderNames;
     }
 
     @Override

--- a/liquidjava-verifier/src/main/java/liquidjava/smt/Counterexample.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/smt/Counterexample.java
@@ -5,4 +5,7 @@ import java.util.List;
 import liquidjava.utils.Pair;
 
 public record Counterexample(List<Pair<String, String>> assignments) {
+    public boolean isEmpty() {
+        return assignments.isEmpty();
+    }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/api/tests/TestCounterexamples.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/api/tests/TestCounterexamples.java
@@ -86,7 +86,7 @@ class TestCounterexamples {
         CommandLineLauncher.launch(TEST_SUITE + test);
         List<LJError> errors = Diagnostics.getInstance().getErrors().stream().toList();
         assertEquals(1, errors.size(), "Expected exactly one error from " + test);
-        return assertInstanceOf(RefinementError.class, errors.getFirst());
+        return assertInstanceOf(RefinementError.class, errors.get(0));
     }
 
     @SafeVarargs

--- a/liquidjava-verifier/src/test/java/liquidjava/api/tests/TestCounterexamples.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/api/tests/TestCounterexamples.java
@@ -1,0 +1,104 @@
+package liquidjava.api.tests;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import liquidjava.api.CommandLineLauncher;
+import liquidjava.diagnostics.Diagnostics;
+import liquidjava.diagnostics.errors.LJError;
+import liquidjava.diagnostics.errors.RefinementError;
+import liquidjava.utils.Pair;
+
+class TestCounterexamples {
+
+    private static final String TEST_SUITE = "../liquidjava-example/src/main/java/testSuite/";
+
+    @Test
+    void recursiveDecrementIncludesInputAndGeneratedArgument() {
+        RefinementError error = verify("ErrorRecursiveDecrement.java");
+        assertAssignments(error, assignment("x", "1"), assignment("#x", "0"));
+    }
+
+    @Test
+    void integerDivisionIncludesInputAndGeneratedReturn() {
+        RefinementError error = verify("ErrorIntegerDivision.java");
+        assertAssignments(error, assignment("x", "1"), assignment("#ret", "0"));
+    }
+
+    @Test
+    void dependentUpperBoundIncludesBoundaryValuesInBinderOrder() {
+        RefinementError error = verify("ErrorDependentUpperBound.java");
+        assertAssignments(error, assignment("len", "1"), assignment("i", "0"), assignment("#ret", "1"));
+    }
+
+    @Test
+    void literalZeroHasNoCounterexampleBecauseValueIsAlreadyKnown() {
+        RefinementError error = verify("ErrorLiteralZero.java");
+        assertTrue(error.getCounterexample().isEmpty());
+    }
+
+    @Test
+    void identityRetainsInputAndReturnSelectedByTheModel() {
+        RefinementError error = verify("ErrorIdentity.java");
+        assertAssignments(error, assignment("x", "0"), assignment("#ret", "0"));
+    }
+
+    @Test
+    void staticFinalConstantHasNoCounterexampleBecauseValueIsAlreadyKnown() {
+        RefinementError error = verify("ErrorStaticFinalConstant.java");
+        assertTrue(error.getCounterexample().isEmpty());
+    }
+
+    @Test
+    void knownReturnAssignmentIsRemovedWhileDependentAssignmentsRemain() {
+        RefinementError error = verify("ErrorDependentRefinement.java");
+        assertAssignments(error, assignment("smaller", "0"), assignment("bigger", "21"));
+    }
+
+    @Test
+    void multipleParametersAndGeneratedReturnFollowBinderOrder() {
+        RefinementError error = verify("ErrorFunctionDeclarations.java");
+        assertAssignments(error, assignment("d", "0"), assignment("i", "1"), assignment("#ret", "2"));
+    }
+
+    @Test
+    void variableUpdateIncludesNegativeInputAndGeneratedReturn() {
+        RefinementError error = verify("ErrorAssignmentBeforeReturn.java");
+        assertAssignments(error, assignment("x", "-1"), assignment("#ret", "0"));
+    }
+
+    @Test
+    void pathConditionIsOmittedWhileRecursiveArgumentRemains() {
+        RefinementError error = verify("ErrorRecursion.java");
+        assertAssignments(error, assignment("k", "0"), assignment("#k", "-1"));
+    }
+
+    @Test
+    void booleanCounterexampleIncludesInputAndGeneratedReturn() {
+        RefinementError error = verify("ErrorBoolean.java");
+        assertAssignments(error, assignment("value", "false"), assignment("#ret", "false"));
+    }
+
+    private static RefinementError verify(String test) {
+        CommandLineLauncher.launch(TEST_SUITE + test);
+        List<LJError> errors = Diagnostics.getInstance().getErrors().stream().toList();
+        assertEquals(1, errors.size(), "Expected exactly one error from " + test);
+        return assertInstanceOf(RefinementError.class, errors.getFirst());
+    }
+
+    @SafeVarargs
+    private static void assertAssignments(RefinementError error, Pair<String, String>... expectedAssignments) {
+        // get counterexample assignments without instance numbers in variable names
+        List<Pair<String, String>> actualAssignments = error.getCounterexample().assignments().stream()
+                .map(assignment -> assignment(assignment.first().replaceAll("_[0-9]+$", ""), assignment.second()))
+                .toList();
+        assertEquals(List.of(expectedAssignments), actualAssignments);
+    }
+
+    private static Pair<String, String> assignment(String name, String value) {
+        return new Pair<>(name, value);
+    }
+}

--- a/liquidjava-verifier/src/test/java/liquidjava/api/tests/TestExamples.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/api/tests/TestExamples.java
@@ -13,8 +13,6 @@ import java.util.stream.Stream;
 
 import liquidjava.api.CommandLineLauncher;
 import liquidjava.diagnostics.Diagnostics;
-import liquidjava.diagnostics.errors.*;
-
 import liquidjava.diagnostics.errors.LJError;
 import liquidjava.utils.Pair;
 


### PR DESCRIPTION
## Description
This PR replaces the expression-based counterexample assignment filtering with VC-based that filters assignments using VC binders and sorts them by binder order.

### Before

```
Found:
∀y. true
∀z. true
∀w¹⁷⁶. y <= w¹⁷⁶ && w¹⁷⁶ <= z

Counterexample:
z == 0
y == 0
w¹⁷⁶ == 0
```

### After

```
Found:
∀y. true
∀z. true
∀w¹⁷⁶. y <= w¹⁷⁶ && w¹⁷⁶ <= z

Counterexample:
y == 0
z == 0
w¹⁷⁶ == 0
```

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Code refactoring

## Checklist
- [x] Added/updated tests
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
