### PR TITLE
Fix Inconsistent Qualified Names

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/classes/conflicting_ghost_names_correct/SimpleTest.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/conflicting_ghost_names_correct/SimpleTest.java
@@ -10,8 +10,10 @@ public class SimpleTest {
         list.get(0);
 
         Stack<Integer> stack = new Stack<>();
-		stack.push(1);
-		stack.peek();
+		if (stack.empty()) {
+			stack.push(1);
+            stack.peek();
+		}
 		stack.pop();
     }
 }

--- a/liquidjava-example/src/main/java/testSuite/classes/conflicting_ghost_names_correct/StackRefinements.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/conflicting_ghost_names_correct/StackRefinements.java
@@ -2,6 +2,7 @@ package testSuite.classes.conflicting_ghost_names_correct;
 
 import liquidjava.specification.ExternalRefinementsFor;
 import liquidjava.specification.Ghost;
+import liquidjava.specification.Refinement;
 import liquidjava.specification.StateRefinement;
 
 @ExternalRefinementsFor("java.util.Stack")
@@ -18,4 +19,7 @@ public interface StackRefinements<E> {
 
 	@StateRefinement(from="size(this) > 0")
 	public E peek();
+
+	@Refinement("_ ? size(this) == 0 : size(this) > 0")
+	public boolean empty();
 }

--- a/liquidjava-verifier/pom.xml
+++ b/liquidjava-verifier/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>io.github.liquid-java</groupId>
 	<artifactId>liquidjava-verifier</artifactId>
-	<version>0.0.27</version>
+	<version>0.0.28</version>
 	<name>liquidjava-verifier</name>
 	<description>LiquidJava Verifier</description>
 	<url>https://github.com/liquid-java/liquidjava</url>

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
@@ -105,7 +105,9 @@ public abstract class TypeChecker extends CtScanner {
             }
         }
         if (ref.isPresent()) {
-            Predicate p = new Predicate(ref.get(), element);
+            String prefix = getQualifiedClassName(element);
+            Predicate p = prefix == null ? new Predicate(ref.get(), element)
+                    : new Predicate(ref.get(), element, prefix);
             if (!p.getExpression().isBooleanExpression()) {
                 SourcePosition position = Utils.getLJAnnotationPosition(element, ref.get());
                 throw new InvalidRefinementError(position, "Refinement predicate must be a boolean expression",

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/FunctionInvocation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/FunctionInvocation.java
@@ -93,7 +93,7 @@ public class FunctionInvocation extends Expression {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((getArgs() == null) ? 0 : getArgs().hashCode());
-        result = prime * result + ((name == null) ? 0 : Utils.getSimpleName(name).hashCode()); // same here
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
         return result;
     }
 
@@ -114,10 +114,7 @@ public class FunctionInvocation extends Expression {
         if (name == null) {
             return other.name == null;
         } else {
-            // prefixes are inconsistent for refined class ghost calls: some use the
-            // original class prefix, others use the caller class prefix
-            // for now we compare simple names, but prefix handling should be fixed instead of having this workaround
-            return other.name != null && Utils.getSimpleName(name).equals(Utils.getSimpleName(other.name));
+            return name.equals(other.name);
         }
     }
 }


### PR DESCRIPTION
## Description
Closes #269.

## Example

[conflicting_ghost_names_correct](https://github.com/liquid-java/liquidjava/tree/fix-269/liquidjava-example/src/main/java/testSuite/classes/conflicting_ghost_names_correct)

### Before

```
Error: Sort mismatch at argument #1 for function (declare-fun java.util.ArrayList.size (java.util.ArrayList) Int) supplied sort is java.util.Stack
12 |         Stack<Integer> stack = new Stack<>();
13 |         if (stack.empty()) {
14 |             stack.push(1);
   |             ^^^^^^^^^^^^^^
15 |             stack.peek();
16 |         }
```

### After

```
Correct! Passed Verification.
```

## Related Issue
#269.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
