### PR TITLE
Fix Instance Variable Leak Between Methods

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/ErrorRecursiveSiblingParameter.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorRecursiveSiblingParameter.java
@@ -1,0 +1,17 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorRecursiveSiblingParameter {
+
+    int fibonacci(@Refinement("_ > 0") int n) {
+        if (n == 1)
+            return 1;
+        else
+            return fibonacci(n - 1) + fibonacci(n - 2); // Refinement Error
+    }
+
+    int factorial(@Refinement("_ > 0") int n) {
+        return n * factorial(n - 1); // Refinement Error
+    }
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/Context.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/Context.java
@@ -40,6 +40,10 @@ public class Context {
     public void reinitializeContext() {
         ctxVars = new Stack<>();
         ctxVars.add(new ArrayList<>()); // global vars
+        clearInstanceVariables();
+    }
+
+    public void clearInstanceVariables() {
         ctxInstanceVars = new ArrayList<>();
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
@@ -105,6 +105,7 @@ public class RefinementTypeChecker extends TypeChecker {
 
     @Override
     public <T> void visitCtConstructor(CtConstructor<T> constructor) {
+        context.clearInstanceVariables();
         context.enterContext();
         mfc.loadFunctionInfo(constructor);
         try {
@@ -117,6 +118,7 @@ public class RefinementTypeChecker extends TypeChecker {
     }
 
     public <R> void visitCtMethod(CtMethod<R> method) {
+        context.clearInstanceVariables();
         context.enterContext();
         if (!method.getSignature().equals("main(java.lang.String[])")) {
             mfc.loadFunctionInfo(method);


### PR DESCRIPTION
## Description
Fixes #270.
Prevents instance variables from leaking between sibling methods by clearing them before checking a new method/constructor.

## Example
```java
int fibonacci(@Refinement("_ > 0") int n) {
    if (n == 1)
        return 1;
    else
        return fibonacci(n - 1) + fibonacci(n - 2); // Refinement Error
}

int factorial(@Refinement("_ > 0") int n) {
    return n * factorial(n - 1); // Refinement Error
}
```

Both invalid recursive calls are now reported.

## Related Issue
#270.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed