### PR TITLE
Remove Unused Fresh Path Binders In Simplification

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCBinderSimplification.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCBinderSimplification.java
@@ -8,11 +8,14 @@ import static liquidjava.rj_language.opt.VCSimplificationUtils.isTrue;
 import liquidjava.processor.VCImplication;
 import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.ast.LiteralBoolean;
+import liquidjava.rj_language.ast.Var;
 
 /**
  * Simplifies VCImplication chains by removing vacuous binder implications
  */
 public class VCBinderSimplification implements VCSimplificationPass {
+
+    private static final String FRESH_PREFIX = "#fresh_";
 
     /**
      * Applies one binder simplification in a VC chain
@@ -47,12 +50,12 @@ public class VCBinderSimplification implements VCSimplificationPass {
     }
 
     /**
-     * Removes a binder whose name is not used in the suffix
+     * Removes a binder that can be omitted from the suffix
      */
     private VCImplication removeBinder(VCImplication implication) {
         VCImplication next = implication.getNext();
 
-        // ∀x. R => P -> P when x is not used in P
+        // ∀x. true => P -> P, and unused generated path conditions can be omitted from diagnostics
         if (next != null)
             return next.clone();
 
@@ -62,13 +65,25 @@ public class VCBinderSimplification implements VCSimplificationPass {
     }
 
     /**
-     * Checks whether a binder is unused and can be removed
+     * Checks whether a binder is unused and can be removed without changing the VC conclusion
      */
     private boolean isRemovableUnusedBinder(VCImplication implication) {
         if (!implication.hasBinder() || containsVar(implication.getNext(), implication.getName()))
             return false;
 
-        return implication.hasNext() || isTrueBinder(implication);
+        return isTrueBinder(implication) || isUnusedFreshPathBinder(implication);
+    }
+
+    /**
+     * Checks for a generated boolean path binder refined exactly by itself
+     */
+    private boolean isUnusedFreshPathBinder(VCImplication implication) {
+        if (!implication.hasNext() || !implication.getName().startsWith(FRESH_PREFIX)
+                || !"boolean".equals(implication.getType().getQualifiedName()))
+            return false;
+
+        return implication.getRefinement().getExpression()instanceof Var var
+                && implication.getName().equals(var.getName());
     }
 
     /**

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCBinderSimplification.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCBinderSimplification.java
@@ -34,8 +34,8 @@ public class VCBinderSimplification implements VCSimplificationPass {
         if (isFalseBinder(implication))
             return collapseFalseBinder(implication);
 
-        if (isTrueBinder(implication) && !containsVar(implication.getNext(), implication.getName()))
-            return removeTrueBinder(implication);
+        if (isRemovableUnusedBinder(implication))
+            return removeBinder(implication);
 
         VCImplication next = simplify(implication.getNext());
         if (next == null)
@@ -47,18 +47,28 @@ public class VCBinderSimplification implements VCSimplificationPass {
     }
 
     /**
-     * Removes a true binder whose name is not used in the suffix
+     * Removes a binder whose name is not used in the suffix
      */
-    private VCImplication removeTrueBinder(VCImplication implication) {
+    private VCImplication removeBinder(VCImplication implication) {
         VCImplication next = implication.getNext();
 
-        // ∀x. true => P -> P
+        // ∀x. R => P -> P when x is not used in P
         if (next != null)
             return next.clone();
 
         // ∀x. true -> true
         Predicate truePredicate = new Predicate(new LiteralBoolean(true));
         return new VCImplication(truePredicate);
+    }
+
+    /**
+     * Checks whether a binder is unused and can be removed
+     */
+    private boolean isRemovableUnusedBinder(VCImplication implication) {
+        if (!implication.hasBinder() || containsVar(implication.getNext(), implication.getName()))
+            return false;
+
+        return implication.hasNext() || isTrueBinder(implication);
     }
 
     /**

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/opt/VCSimplificationResult.java
@@ -1,7 +1,5 @@
 package liquidjava.rj_language.opt;
 
-import java.util.Objects;
-
 import liquidjava.processor.VCImplication;
 
 /**

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCBinderSimplificationTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCBinderSimplificationTest.java
@@ -13,6 +13,16 @@ class VCBinderSimplificationTest {
     }
 
     @Test
+    void removesNonTrueBinderWhenVariableIsUnusedDownstream() {
+        assertSimplificationSteps(binderSimplification, vc("∀x:int. x > 0", "y > 0"), step("y > 0"));
+    }
+
+    @Test
+    void keepsNonTrueTerminalBinderAsConclusion() {
+        assertSimplificationSteps(binderSimplification, vc("∀x:int. x > 0"), step("x > 0"));
+    }
+
+    @Test
     void keepsTrueBinderWhenVariableIsUsedDownstream() {
         assertSimplificationSteps(binderSimplification, vc("∀x:int. true", "x > 0"), step("true", "x > 0"));
     }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCBinderSimplificationTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCBinderSimplificationTest.java
@@ -13,8 +13,13 @@ class VCBinderSimplificationTest {
     }
 
     @Test
-    void removesNonTrueBinderWhenVariableIsUnusedDownstream() {
-        assertSimplificationSteps(binderSimplification, vc("∀x:int. x > 0", "y > 0"), step("y > 0"));
+    void removesFreshPathBinderWhenVariableIsUnusedDownstream() {
+        assertSimplificationSteps(binderSimplification, vc("∀#fresh_1:boolean. #fresh_1", "y > 0"), step("y > 0"));
+    }
+
+    @Test
+    void keepsNonTrueBinderWhenVariableIsUnusedDownstream() {
+        assertSimplificationSteps(binderSimplification, vc("∀x:int. x > 0", "y > 0"), step("x > 0", "y > 0"));
     }
 
     @Test

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCSimplificationTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCSimplificationTest.java
@@ -108,14 +108,13 @@ class VCSimplificationTest {
     }
 
     @Test
-    void simplifyUsesFoldingToEnableBinderSimplificationOnNextStep() {
-        assertSimplificationSteps(vc("∀x:int. 1 > 2", "y > 0"), step("false", "y > 0"), step("true"));
+    void simplifyRemovesUnusedBinderBeforeFolding() {
+        assertSimplificationSteps(vc("∀x:int. 1 > 2", "y > 0"), step("y > 0"));
     }
 
     @Test
-    void simplifyUsesArithmeticAndLogicalSimplificationToEnableBinderRemoval() {
-        assertSimplificationSteps(vc("∀x:int. x + 0 == x", "y > 0"), step("x == x", "y > 0"), step("true", "y > 0"),
-                step("y > 0"));
+    void simplifyRemovesUnusedBinderBeforeArithmeticAndLogicalSimplification() {
+        assertSimplificationSteps(vc("∀x:int. x + 0 == x", "y > 0"), step("y > 0"));
     }
 
     @Test

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCSimplificationTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/opt/VCSimplificationTest.java
@@ -108,13 +108,14 @@ class VCSimplificationTest {
     }
 
     @Test
-    void simplifyRemovesUnusedBinderBeforeFolding() {
-        assertSimplificationSteps(vc("∀x:int. 1 > 2", "y > 0"), step("y > 0"));
+    void simplifyUsesFoldingToEnableBinderSimplificationOnNextStep() {
+        assertSimplificationSteps(vc("∀x:int. 1 > 2", "y > 0"), step("false", "y > 0"), step("true"));
     }
 
     @Test
-    void simplifyRemovesUnusedBinderBeforeArithmeticAndLogicalSimplification() {
-        assertSimplificationSteps(vc("∀x:int. x + 0 == x", "y > 0"), step("y > 0"));
+    void simplifyUsesArithmeticAndLogicalSimplificationToEnableBinderRemoval() {
+        assertSimplificationSteps(vc("∀x:int. x + 0 == x", "y > 0"), step("x == x", "y > 0"), step("true", "y > 0"),
+                step("y > 0"));
     }
 
     @Test

--- a/liquidjava-verifier/src/test/java/liquidjava/utils/VCTestUtils.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/utils/VCTestUtils.java
@@ -13,11 +13,12 @@ import liquidjava.rj_language.opt.VCSimplificationPass;
 import liquidjava.rj_language.opt.VCSimplificationResult;
 import liquidjava.rj_language.parsing.RefinementsParser;
 import spoon.Launcher;
+import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
 
 public class VCTestUtils {
 
-    private static final CtTypeReference<?> INT = new Launcher().getFactory().Type().INTEGER_PRIMITIVE;
+    private static final TypeFactory TYPE_FACTORY = new Launcher().getFactory().Type();
 
     public static VCImplication vc(String... implications) {
         VCImplication first = null;
@@ -97,7 +98,9 @@ public class VCTestUtils {
 
     private static CtTypeReference<?> type(String name) {
         if ("int".equals(name))
-            return INT;
+            return TYPE_FACTORY.INTEGER_PRIMITIVE;
+        if ("boolean".equals(name))
+            return TYPE_FACTORY.BOOLEAN_PRIMITIVE;
         throw new IllegalArgumentException("Unsupported test type: " + name);
     }
 


### PR DESCRIPTION
## Description
This PR updates VC binder simplification to remove unused path binders of the form `∀#fresh_n:boolean. #fresh_n` that are generated from conditional branches.

## Example
```text
∀#fresh_1:boolean. #fresh_1 =>
∀x:int. x > 0
```

is simplified to:

```text
∀x:int. x > 0
```

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed