### PR TITLE
Fix NPE When Incrementing Fields

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/field_updates/CorrectFieldIncrement.java
+++ b/liquidjava-example/src/main/java/testSuite/field_updates/CorrectFieldIncrement.java
@@ -1,0 +1,10 @@
+package testSuite.field_updates;
+
+public class CorrectFieldIncrement {
+
+    private int field;
+
+    public void increment() {
+        field++;
+    }
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/OperationsChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/OperationsChecker.java
@@ -25,6 +25,7 @@ import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.code.CtFieldWrite;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
@@ -39,7 +40,6 @@ import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
-import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.support.reflect.code.CtIfImpl;
@@ -123,6 +123,8 @@ public class OperationsChecker {
         Predicate all;
         if (ex instanceof CtVariableWrite<T> w) {
             name = w.getVariable().getSimpleName();
+            if (w instanceof CtFieldWrite<?>)
+                name = String.format(Formats.THIS, name);
             all = getRefinementUnaryVariableWrite(ex, operator, w, name);
             rtc.checkVariableRefinements(all, name, w.getType(), operator, w.getVariable().getDeclaration());
             return;
@@ -389,9 +391,8 @@ public class OperationsChecker {
     private <T> Predicate getRefinementUnaryVariableWrite(CtExpression<T> ex, CtUnaryOperator<T> operator,
             CtVariableWrite<T> w, String name) throws LJError {
         String newName = String.format(Formats.INSTANCE, name, rtc.getContext().getCounter());
-        CtVariable<T> varDecl = w.getVariable().getDeclaration();
 
-        Predicate metadada = rtc.getContext().getVariableRefinements(varDecl.getSimpleName());
+        Predicate metadada = rtc.getContext().getVariableRefinements(name);
         metadada = metadada.substituteVariable(Keys.WILDCARD, newName);
         metadada = metadada.substituteVariable(name, newName);
 


### PR DESCRIPTION
## Description
Fixes a null pointer exception when applying unary update operators such as `field++` to class fields.
This fix also applies to other unary field updates such as `field--`, `++field`, and `--field`.

## Example

```java
public class Test {
    private int field;

    public void increment() {
        field++; // crash
    }
}
```

## Related Issue
None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist

- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed