### PR TITLE
Fix Field Initialization

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/classes/state_field_initializer_correct/StateFieldInitializer.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/state_field_initializer_correct/StateFieldInitializer.java
@@ -1,0 +1,23 @@
+package testSuite.classes.state_field_initializer_correct;
+
+import liquidjava.specification.Ghost;
+import liquidjava.specification.StateRefinement;
+
+public class StateFieldInitializer {
+
+    private final Obj obj = new Obj();
+
+    public void test() {
+        obj.foo();
+    }
+}
+
+@Ghost("boolean ready")
+class Obj {
+
+    @StateRefinement(to="ready(this)")
+    Obj() {}
+
+    @StateRefinement(from="ready(this)")
+    void foo() {}
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/Context.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/Context.java
@@ -47,6 +47,14 @@ public class Context {
         ctxInstanceVars = new ArrayList<>();
     }
 
+    public void restoreInstanceVariables() {
+        for (RefinedVariable variable : getCtxVars()) {
+            if (variable instanceof Variable) {
+                ((Variable) variable).getLastInstance().ifPresent(this::addInstanceVariable);
+            }
+        }
+    }
+
     public void reinitializeAllContext() {
         reinitializeContext();
         ctxFunctions = new ArrayList<>();

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
@@ -266,6 +266,11 @@ public class RefinementTypeChecker extends TypeChecker {
             ret = c.get().substituteVariable(Keys.WILDCARD, name).substituteVariable(f.getSimpleName(), name);
         }
         RefinedVariable v = context.addVarToContext(name, f.getType(), ret, f);
+        if (f.getAssignment() != null) {
+            Predicate refinement = getRefinement(f.getAssignment());
+            checkVariableRefinements(refinement != null ? refinement : new Predicate(), name, f.getType(), f, f);
+            AuxStateHandler.addStateRefinements(this, name, f.getAssignment());
+        }
         getMessageFromAnnotation(f).ifPresent(v::setMessage);
         if (v instanceof Variable) {
             ((Variable) v).setLocation("this");

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/RefinementTypeChecker.java
@@ -107,6 +107,7 @@ public class RefinementTypeChecker extends TypeChecker {
     public <T> void visitCtConstructor(CtConstructor<T> constructor) {
         context.clearInstanceVariables();
         context.enterContext();
+        context.restoreInstanceVariables();
         mfc.loadFunctionInfo(constructor);
         try {
             super.visitCtConstructor(constructor);
@@ -121,6 +122,7 @@ public class RefinementTypeChecker extends TypeChecker {
     public <R> void visitCtMethod(CtMethod<R> method) {
         context.clearInstanceVariables();
         context.enterContext();
+        context.restoreInstanceVariables();
         if (!method.getSignature().equals("main(java.lang.String[])")) {
             mfc.loadFunctionInfo(method);
         }


### PR DESCRIPTION
## Description
This PR makes constructors preserve state refinements when an object is assigned directly to a class field.
Field initializers were visited but their refinement metadata was not transferred to the field’s symbolic instance.

## Example

```java
public class Test {

    private final Obj obj = new Obj();

    public void test() {
        obj.foo(); // reports state refinement error but should pass
    }
}

@Ghost("boolean ready")
class Obj {

    @StateRefinement(to = "ready(this)")
    Obj() {}

    @StateRefinement(from = "ready(this)")
    void foo() {}
}
```

## Related Issue
None.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed