### PR TITLE
Fix NPE When Concatenating Strings

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/OperationsChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/OperationsChecker.java
@@ -72,6 +72,10 @@ public class OperationsChecker {
         if (parent instanceof CtAnnotation)
             return; // Operations in annotations are not handled here
 
+        String type = operator.getType().getQualifiedName();
+        if (type.equals("java.lang.String"))
+            return;
+
         if (parent instanceof CtAssignment<?, ?>
                 && ((CtAssignment<?, ?>) parent).getAssigned()instanceof CtVariableWrite<?> parentVar) {
             oper = getOperationRefinements(operator, parentVar, operator);
@@ -81,7 +85,6 @@ public class OperationsChecker {
             Predicate varRight = getOperationRefinements(operator, right);
             oper = Predicate.createOperation(varLeft, getOperatorFromKind(operator.getKind()), varRight);
         }
-        String type = operator.getType().getQualifiedName();
         List<String> types = Arrays.asList(Types.IMPLEMENTED);
         if (type.contentEquals("boolean")) {
             operator.putMetadata(Keys.REFINEMENT, oper);
@@ -90,8 +93,6 @@ public class OperationsChecker {
                 operator.putMetadata(Keys.REFINEMENT, Predicate.createEquals(Predicate.createVar(Keys.WILDCARD), oper));
         } else if (types.contains(type)) {
             operator.putMetadata(Keys.REFINEMENT, Predicate.createEquals(Predicate.createVar(Keys.WILDCARD), oper));
-        } else if (type.equals("java.lang.String")) {
-            // skip strings
         } else {
             throw new NotImplementedException("Literal type not implemented");
         }


### PR DESCRIPTION
## Description
This PR fixes a crash when concatenating an unrefined function invocation with a string.
The previous fix added in #89 was not enough because it ran only after processing both operands, allowing a null `RefinedFunction` to cause a `NullPointerException`.

## Example
```java
String str = object.toString() + "hello"; // crash
```

## Related Issue
None.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
