### PR TITLE
Simplify Unambiguous Qualified Names

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/ExpressionFormatter.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/ExpressionFormatter.java
@@ -19,7 +19,6 @@ import liquidjava.rj_language.ast.Enum;
 import liquidjava.rj_language.ast.UnaryExpression;
 import liquidjava.rj_language.ast.Var;
 import liquidjava.rj_language.visitors.ExpressionVisitor;
-import liquidjava.utils.Utils;
 
 /**
  * Formatter for expressions that only adds parentheses when required by precedence and associativity rules and formats
@@ -27,12 +26,18 @@ import liquidjava.utils.Utils;
  */
 public class ExpressionFormatter implements ExpressionVisitor<String> {
 
+    private final ExpressionNameResolver nameResolver;
+
+    private ExpressionFormatter(Expression expression) {
+        this.nameResolver = ExpressionNameResolver.forExpression(expression);
+    }
+
     public static String format(Predicate predicate) {
         return format(predicate.getExpression());
     }
 
     public static String format(Expression expression) {
-        return new ExpressionFormatter().formatExpression(expression);
+        return new ExpressionFormatter(expression).formatExpression(expression);
     }
 
     private String formatExpression(Expression expression) {
@@ -108,7 +113,7 @@ public class ExpressionFormatter implements ExpressionVisitor<String> {
 
     @Override
     public String visitFunctionInvocation(FunctionInvocation fun) {
-        return Utils.getSimpleName(fun.getName()) + "(" + formatArguments(fun.getArgs()) + ")";
+        return nameResolver.resolveFunction(fun.getName()) + "(" + formatArguments(fun.getArgs()) + ")";
     }
 
     @Override
@@ -159,6 +164,6 @@ public class ExpressionFormatter implements ExpressionVisitor<String> {
 
     @Override
     public String visitVar(Var var) {
-        return VariableFormatter.format(var.getName());
+        return nameResolver.resolveVariable(var.getName());
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/ExpressionNameResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/ExpressionNameResolver.java
@@ -1,0 +1,44 @@
+package liquidjava.rj_language.ast.formatter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import liquidjava.rj_language.ast.Expression;
+import liquidjava.rj_language.ast.FunctionInvocation;
+import liquidjava.rj_language.ast.Var;
+import liquidjava.utils.Utils;
+
+/** Simplifies unambiguous qualified names within one expression */
+final class ExpressionNameResolver {
+    private final Set<String> variables = new HashSet<>();
+    private final Set<String> functions = new HashSet<>();
+
+    public static ExpressionNameResolver forExpression(Expression expression) {
+        ExpressionNameResolver resolver = new ExpressionNameResolver();
+        resolver.collect(expression);
+        return resolver;
+    }
+
+    public String resolveVariable(String name) {
+        return resolve(VariableFormatter.format(name), variables);
+    }
+
+    public String resolveFunction(String name) {
+        return resolve(name, functions);
+    }
+
+    private void collect(Expression expression) {
+        if (expression instanceof Var var)
+            variables.add(VariableFormatter.format(var.getName()));
+        else if (expression instanceof FunctionInvocation function)
+            functions.add(function.getName());
+        expression.getChildren().forEach(this::collect);
+    }
+
+    private static String resolve(String name, Set<String> names) {
+        String simpleName = Utils.getSimpleName(name);
+        boolean ambiguous = names.stream()
+                .anyMatch(other -> !other.equals(name) && Utils.getSimpleName(other).equals(simpleName));
+        return ambiguous ? name : simpleName;
+    }
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/ExpressionNameResolver.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/ExpressionNameResolver.java
@@ -2,6 +2,7 @@ package liquidjava.rj_language.ast.formatter;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 import liquidjava.rj_language.ast.Expression;
 import liquidjava.rj_language.ast.FunctionInvocation;
@@ -20,25 +21,29 @@ final class ExpressionNameResolver {
     }
 
     public String resolveVariable(String name) {
-        return resolve(VariableFormatter.format(name), variables);
+        String formatted = VariableFormatter.format(name);
+        return isAmbiguous(name, variables, ExpressionNameResolver::getVariableSimpleName) ? formatted
+                : Utils.getSimpleName(formatted);
     }
 
     public String resolveFunction(String name) {
-        return resolve(name, functions);
+        return isAmbiguous(name, functions, Utils::getSimpleName) ? name : Utils.getSimpleName(name);
     }
 
     private void collect(Expression expression) {
         if (expression instanceof Var var)
-            variables.add(VariableFormatter.format(var.getName()));
-        else if (expression instanceof FunctionInvocation function)
-            functions.add(function.getName());
+            variables.add(var.getName());
+        else if (expression instanceof FunctionInvocation fun)
+            functions.add(fun.getName());
         expression.getChildren().forEach(this::collect);
     }
 
-    private static String resolve(String name, Set<String> names) {
-        String simpleName = Utils.getSimpleName(name);
-        boolean ambiguous = names.stream()
-                .anyMatch(other -> !other.equals(name) && Utils.getSimpleName(other).equals(simpleName));
-        return ambiguous ? name : simpleName;
+    private static String getVariableSimpleName(String name) {
+        return Utils.getSimpleName(VariableFormatter.withoutInstance(name));
+    }
+
+    private static boolean isAmbiguous(String name, Set<String> names, Function<String, String> getSimpleName) {
+        String simpleName = getSimpleName.apply(name);
+        return names.stream().anyMatch(other -> !other.equals(name) && getSimpleName.apply(other).equals(simpleName));
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/VariableFormatter.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/formatter/VariableFormatter.java
@@ -24,6 +24,11 @@ public final class VariableFormatter {
         return prefix + baseName + toSuperscript(counter);
     }
 
+    public static String withoutInstance(String name) {
+        Matcher matcher = INSTACE_VAR_PATTERN.matcher(name);
+        return matcher.matches() ? matcher.group(1) : name;
+    }
+
     private static String toSuperscript(String number) {
         StringBuilder sb = new StringBuilder(number.length());
         for (char c : number.toCharArray()) {

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/ExpressionFormatterTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/ExpressionFormatterTest.java
@@ -9,11 +9,15 @@ import liquidjava.rj_language.parsing.RefinementsParser;
 class ExpressionFormatterTest {
 
     private static Expression parse(String refinement) {
-        return RefinementsParser.createAST(refinement, "");
+        return parse(refinement, "");
+    }
+
+    private static Expression parse(String refinement, String prefix) {
+        return RefinementsParser.createAST(refinement, prefix);
     }
 
     @Test
-    void formatsUnaryAtoms() {
+    void formatsUnary() {
         assertEquals("!x", parse("!x").toDisplayString());
         assertEquals("!false", parse("!false").toDisplayString());
     }
@@ -50,7 +54,7 @@ class ExpressionFormatterTest {
     }
 
     @Test
-    void omitsUnnecessaryGroupParentheses() {
+    void formatsGrouping() {
         assertEquals("x", parse("(x)").toDisplayString());
         assertEquals("x", parse("((x))").toDisplayString());
         assertEquals("1", parse("(1)").toDisplayString());
@@ -96,5 +100,19 @@ class ExpressionFormatterTest {
         assertEquals("a ? b : (c ? d : e)", parse("a ? b : (c ? d : e)").toDisplayString());
         assertEquals("a ? b : (c ? d : (e ? f : g))", parse("a ? b : c ? d : e ? f : g").toDisplayString());
         assertEquals("a ? b : c", parse("a ? b : c").toDisplayString());
+    }
+
+    @Test
+    void formatsWithQualifiedNames() {
+        Expression exp = new BinaryExpression(parse("size(this)", "java.util.ArrayList"), "==",
+                parse("size(this)", "java.util.ArrayDeque"));
+        assertEquals("java.util.ArrayList.size(this) == java.util.ArrayDeque.size(this)",
+                exp.toDisplayString());
+    }
+
+    @Test
+    void formatsWithoutQualifiedNames() {
+        assertEquals("size(this)", parse("size(this)", "java.util.List").toDisplayString());
+        assertEquals("size(this) == size(this)", parse("size(this) == size(this)", "java.util.List").toDisplayString());
     }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/ExpressionFormatterTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/ExpressionFormatterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.parsing.RefinementsParser;
 
 class ExpressionFormatterTest {
@@ -106,13 +107,17 @@ class ExpressionFormatterTest {
     void formatsWithQualifiedNames() {
         Expression exp = new BinaryExpression(parse("size(this)", "java.util.ArrayList"), "==",
                 parse("size(this)", "java.util.ArrayDeque"));
-        assertEquals("java.util.ArrayList.size(this) == java.util.ArrayDeque.size(this)",
-                exp.toDisplayString());
+        assertEquals("java.util.ArrayList.size(this) == java.util.ArrayDeque.size(this)", exp.toDisplayString());
+
+        Predicate differentInstances = Predicate.createEquals(Predicate.createVar("#java.util.ArrayList.size_1"),
+                Predicate.createVar("#java.util.ArrayDeque.size_2"));
+        assertEquals("java.util.ArrayList.size¹ == java.util.ArrayDeque.size²",
+                differentInstances.getExpression().toDisplayString());
     }
 
     @Test
     void formatsWithoutQualifiedNames() {
         assertEquals("size(this)", parse("size(this)", "java.util.List").toDisplayString());
-        assertEquals("size(this) == size(this)", parse("size(this) == size(this)", "java.util.List").toDisplayString());
+        assertEquals("size(this) == size(this)", parse("size(this) == size(this)", "java.util.List").toDisplayString());   
     }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/ExpressionFormatterTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/ExpressionFormatterTest.java
@@ -4,32 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.parsing.RefinementsParser;
 
 class ExpressionFormatterTest {
 
     private static Expression parse(String refinement) {
-        return parse(refinement, "");
-    }
-
-    private static Expression parse(String refinement, String prefix) {
-        return RefinementsParser.createAST(refinement, prefix);
+        return RefinementsParser.createAST(refinement, "");
     }
 
     @Test
     void formatsUnary() {
         assertEquals("!x", parse("!x").toDisplayString());
         assertEquals("!false", parse("!false").toDisplayString());
-    }
-
-    @Test
-    void formatsInternalVariables() {
-        assertEquals("x", parse("x").toDisplayString());
-        assertEquals("x²", parse("#x_2").toDisplayString());
-        assertEquals("#fresh¹²", parse("#fresh_12").toDisplayString());
-        assertEquals("#ret³", parse("#ret_3").toDisplayString());
-        assertEquals("this#Class", parse("this#Class").toDisplayString());
     }
 
     @Test
@@ -103,21 +89,4 @@ class ExpressionFormatterTest {
         assertEquals("a ? b : c", parse("a ? b : c").toDisplayString());
     }
 
-    @Test
-    void formatsWithQualifiedNames() {
-        Expression exp = new BinaryExpression(parse("size(this)", "java.util.ArrayList"), "==",
-                parse("size(this)", "java.util.ArrayDeque"));
-        assertEquals("java.util.ArrayList.size(this) == java.util.ArrayDeque.size(this)", exp.toDisplayString());
-
-        Predicate differentInstances = Predicate.createEquals(Predicate.createVar("#java.util.ArrayList.size_1"),
-                Predicate.createVar("#java.util.ArrayDeque.size_2"));
-        assertEquals("java.util.ArrayList.size¹ == java.util.ArrayDeque.size²",
-                differentInstances.getExpression().toDisplayString());
-    }
-
-    @Test
-    void formatsWithoutQualifiedNames() {
-        assertEquals("size(this)", parse("size(this)", "java.util.List").toDisplayString());
-        assertEquals("size(this) == size(this)", parse("size(this) == size(this)", "java.util.List").toDisplayString());   
-    }
 }

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/formatter/ExpressionNameResolverTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/formatter/ExpressionNameResolverTest.java
@@ -1,0 +1,45 @@
+package liquidjava.rj_language.ast.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import liquidjava.rj_language.Predicate;
+import liquidjava.rj_language.ast.BinaryExpression;
+import liquidjava.rj_language.ast.Expression;
+import liquidjava.rj_language.parsing.RefinementsParser;
+
+class ExpressionNameResolverTest {
+
+    private static Expression parse(String refinement, String prefix) {
+        return RefinementsParser.createAST(refinement, prefix);
+    }
+
+    @Test
+    void stripsQualifiedNamesWhenUnambiguous() {
+        ExpressionNameResolver resolver = ExpressionNameResolver
+                .forExpression(parse("size(this) == size(this)", "java.util.List"));
+
+        assertEquals("size", resolver.resolveFunction("java.util.List.size"));
+    }
+
+    @Test
+    void keepsQualifiedNamesForDifferentPrefixes() {
+        Expression expression = new BinaryExpression(parse("size(this)", "java.util.ArrayList"), "==",
+                parse("size(this)", "java.util.ArrayDeque"));
+        ExpressionNameResolver resolver = ExpressionNameResolver.forExpression(expression);
+
+        assertEquals("java.util.ArrayList.size", resolver.resolveFunction("java.util.ArrayList.size"));
+        assertEquals("java.util.ArrayDeque.size", resolver.resolveFunction("java.util.ArrayDeque.size"));
+    }
+
+    @Test
+    void keepsQualifiedNamesForDifferentInstances() {
+        Predicate differentInstances = Predicate.createEquals(Predicate.createVar("#java.util.ArrayList.size_1"),
+                Predicate.createVar("#java.util.ArrayDeque.size_2"));
+        ExpressionNameResolver resolver = ExpressionNameResolver.forExpression(differentInstances.getExpression());
+
+        assertEquals("java.util.ArrayList.size¹", resolver.resolveVariable("#java.util.ArrayList.size_1"));
+        assertEquals("java.util.ArrayDeque.size²", resolver.resolveVariable("#java.util.ArrayDeque.size_2"));
+    }
+}

--- a/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/formatter/VariableFormatterTest.java
+++ b/liquidjava-verifier/src/test/java/liquidjava/rj_language/ast/formatter/VariableFormatterTest.java
@@ -1,0 +1,17 @@
+package liquidjava.rj_language.ast.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class VariableFormatterTest {
+
+    @Test
+    void formatsVariables() {
+        assertEquals("x", VariableFormatter.format("x"));
+        assertEquals("x²", VariableFormatter.format("#x_2"));
+        assertEquals("#fresh¹²", VariableFormatter.format("#fresh_12"));
+        assertEquals("#ret³", VariableFormatter.format("#ret_3"));
+        assertEquals("this#Class", VariableFormatter.format("this#Class"));
+    }
+}


### PR DESCRIPTION
## Description
This PR improves expression formatting by displaying simple variable and function names when unambiguous.
We were previously always simplifying function names and never simplifying variable names, which are both wrong.
We now preserve qualified names when they share the same simple name within an expression.

## Example

#### Unambiguous

```java
java.util.ArrayList.size(this) == java.util.ArrayList.size(this)
```
simplifies to
```java
size(this) == size(this)
```

#### Ambiguous
```java
java.util.ArrayList.size(this) == java.util.ArrayDeque.size(this) 
```
does not simplify

## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [x] Added/updated tests
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed