### PR TITLE
Add Declaration Location to Refinement Errors

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
@@ -47,6 +47,10 @@ public class LJDiagnostic extends RuntimeException {
         return position;
     }
 
+    public SourcePosition getDeclarationPosition() {
+        return null;
+    }
+
     public void setPosition(SourcePosition pos) {
         if (pos == null || pos.getFile() == null)
             return;
@@ -89,6 +93,13 @@ public class LJDiagnostic extends RuntimeException {
         // location
         if (file != null && position != null) {
             sb.append("\n").append(file).append(":").append(position.getLine()).append(Colors.RESET).append("\n");
+        }
+
+        // declaration position
+        SourcePosition declPos = getDeclarationPosition();
+        if (declPos != null && declPos.getFile() != null && !declPos.equals(position)) {
+            sb.append("↳ ").append(declPos.getFile().getPath()).append(":").append(declPos.getLine())
+                    .append(Colors.RESET).append("\n");
         }
 
         return sb.toString();

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
@@ -98,27 +98,35 @@ public class LJDiagnostic extends RuntimeException {
         // declaration position
         SourcePosition declPos = getDeclarationPosition();
         if (declPos != null && declPos.getFile() != null && !declPos.equals(position)) {
-            sb.append("↳ ").append(declPos.getFile().getPath()).append(":").append(declPos.getLine())
-                    .append(Colors.RESET).append("\n");
+            sb.append(Colors.CYAN).append("\n--> Refinement declared here:\n").append(Colors.RESET);
+            String declarationSnippet = getSnippet(declPos, 1, 0, Colors.CYAN, null, true);
+            if (declarationSnippet != null) {
+                sb.append(declarationSnippet);
+            }
+            sb.append(declPos.getFile().getPath()).append(":").append(declPos.getLine()).append(Colors.RESET)
+                    .append("\n");
         }
 
         return sb.toString();
     }
 
     public String getSnippet() {
-        if (file == null || position == null)
+        return getSnippet(position, 2, 2, accentColor, customMessage, false);
+    }
+
+    private String getSnippet(SourcePosition snippetPosition, int contextBefore, int contextAfter, String markerColor,
+            String markerMessage, boolean firstLineOnly) {
+        if (snippetPosition == null || snippetPosition.getFile() == null)
             return null;
 
-        Path path = Path.of(file);
+        Path path = snippetPosition.getFile().toPath();
         try {
             List<String> lines = Files.readAllLines(path);
             StringBuilder sb = new StringBuilder();
 
-            // before and after lines for context
-            int contextBefore = 2;
-            int contextAfter = 2;
-            int startLine = Math.max(1, position.getLine() - contextBefore);
-            int endLine = Math.min(lines.size(), position.getEndLine() + contextAfter);
+            int startLine = Math.max(1, snippetPosition.getLine() - contextBefore);
+            int highlightedEndLine = firstLineOnly ? snippetPosition.getLine() : snippetPosition.getEndLine();
+            int endLine = Math.min(lines.size(), highlightedEndLine + contextAfter);
 
             // calculate padding for line numbers
             int padding = String.valueOf(endLine).length();
@@ -132,9 +140,10 @@ public class LJDiagnostic extends RuntimeException {
                 sb.append(Colors.GREY).append(lineNumStr).append(PIPE).append(line).append(Colors.RESET).append("\n");
 
                 // add error markers on the line(s) with the error
-                if (i >= position.getLine() && i <= position.getEndLine()) {
-                    int colStart = (i == position.getLine()) ? position.getColumn() : 1;
-                    int colEnd = (i == position.getEndLine()) ? position.getEndColumn() : rawLine.length();
+                if (i >= snippetPosition.getLine() && i <= highlightedEndLine) {
+                    int colStart = (i == snippetPosition.getLine()) ? snippetPosition.getColumn() : 1;
+                    int colEnd = (i == snippetPosition.getEndLine()) ? snippetPosition.getEndColumn()
+                            : rawLine.length();
 
                     if (colStart > 0 && colEnd > 0) {
                         int tabsBeforeStart = (int) rawLine.substring(0, Math.max(0, colStart - 1)).chars()
@@ -147,13 +156,13 @@ public class LJDiagnostic extends RuntimeException {
                         // line number padding + pipe + column offset
                         String indent = " ".repeat(padding) + Colors.GREY + PIPE + Colors.RESET
                                 + " ".repeat(visualColStart - 1);
-                        String markers = accentColor + "^".repeat(Math.max(1, visualColEnd - visualColStart + 1));
+                        String markers = markerColor + "^".repeat(Math.max(1, visualColEnd - visualColStart + 1));
                         sb.append(indent).append(markers);
 
                         // custom message
-                        if (customMessage != null && !customMessage.isBlank()) {
+                        if (markerMessage != null && !markerMessage.isBlank()) {
                             String offset = " ".repeat(padding + visualColEnd + PIPE.length() + 1);
-                            sb.append(" " + customMessage.replace("\n", "\n" + offset));
+                            sb.append(" " + markerMessage.replace("\n", "\n" + offset));
                         }
                         sb.append(Colors.RESET).append("\n");
                     }

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -23,9 +23,11 @@ public class RefinementError extends LJError {
     private final Predicate expected;
     private final VCSimplificationResult found;
     private final Counterexample counterexample;
+    private final SourcePosition declarationPosition;
 
-    public RefinementError(SourcePosition position, Predicate expected, VCSimplificationResult found,
-            TranslationTable translationTable, Counterexample counterexample, String customMessage) {
+    public RefinementError(SourcePosition position, SourcePosition declarationPosition, Predicate expected,
+            VCSimplificationResult found, TranslationTable translationTable, Counterexample counterexample,
+            String customMessage) {
         super("Refinement Error",
                 String.format("%s is not a subtype of %s",
                         found.getImplication().toPredicate().getExpression().toDisplayString(),
@@ -34,6 +36,12 @@ public class RefinementError extends LJError {
         this.expected = expected;
         this.found = found;
         this.counterexample = counterexample;
+        this.declarationPosition = declarationPosition;
+    }
+
+    @Override
+    public SourcePosition getDeclarationPosition() {
+        return declarationPosition;
     }
 
     @Override

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
@@ -15,15 +15,23 @@ public class StateRefinementError extends LJError {
 
     private final Predicate expected;
     private final VCSimplificationResult found;
+    private final SourcePosition declarationPosition;
 
-    public StateRefinementError(SourcePosition position, Predicate expected, VCSimplificationResult found,
-            TranslationTable translationTable, String customMessage) {
+    public StateRefinementError(SourcePosition position, SourcePosition declarationPosition, Predicate expected,
+            VCSimplificationResult found, TranslationTable translationTable, String customMessage) {
         super("State Refinement Error",
-                String.format("Expected state %s but found %s", expected.getExpression().toDisplayString(),
-                        found.getImplication().toPredicate().getExpression().toDisplayString()),
+                String.format("found %s but expected %s",
+                        found.getImplication().toPredicate().getExpression().toDisplayString(),
+                        expected.getExpression().toDisplayString()),
                 position, translationTable, customMessage);
+        this.declarationPosition = declarationPosition;
         this.expected = expected;
         this.found = found;
+    }
+
+    @Override
+    public SourcePosition getDeclarationPosition() {
+        return declarationPosition;
     }
 
     public Predicate getExpected() {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
@@ -362,22 +362,21 @@ public abstract class TypeChecker extends CtScanner {
             rv.addSuperType(t);
         context.addRefinementInstanceToVariable(simpleName, newName);
         String customMessage = getMessageFromAnnotation(variable).orElse(mainRV != null ? mainRV.getMessage() : null);
-        checkSMT(cEt, usage, customMessage); // TODO CHANGE
+        checkSMT(cEt, usage, variable.getPosition(), customMessage); // TODO CHANGE
         context.addRefinementToVariableInContext(simpleName, type, cet, usage);
     }
 
-    public void checkSMT(Predicate expectedType, CtElement element) throws LJError {
-        checkSMT(expectedType, element, null);
-    }
-
-    public void checkSMT(Predicate expectedType, CtElement element, String customMessage) throws LJError {
-        vcChecker.processSubtyping(expectedType, context.getGhostStates(), element, factory, customMessage);
+    public void checkSMT(Predicate expectedType, CtElement element, SourcePosition declarationPosition,
+            String customMessage) throws LJError {
+        vcChecker.processSubtyping(expectedType, context.getGhostStates(), element, factory, declarationPosition,
+                customMessage);
         element.putMetadata(Keys.REFINEMENT, expectedType);
     }
 
-    public void checkStateSMT(Predicate prevState, Predicate expectedState, CtElement target, String moreInfo)
-            throws LJError {
-        vcChecker.processSubtyping(prevState, expectedState, context.getGhostStates(), target, factory);
+    public void checkStateSMT(Predicate prevState, Predicate expectedState, CtElement target,
+            SourcePosition declarationPosition, String moreInfo) throws LJError {
+        vcChecker.processSubtyping(prevState, expectedState, context.getGhostStates(), target, declarationPosition,
+                factory);
     }
 
     public boolean checkStateSMT(Predicate prevState, Predicate expectedState, SourcePosition p) throws LJError {
@@ -391,14 +390,14 @@ public abstract class TypeChecker extends CtScanner {
         return result.isOk();
     }
 
-    public void throwRefinementError(SourcePosition position, Predicate expectedType, Predicate foundType,
-            String customMessage) throws LJError {
-        vcChecker.throwRefinementError(position, expectedType, foundType, null, customMessage);
+    public void throwRefinementError(SourcePosition position, SourcePosition declarationPosition,
+            Predicate expectedType, Predicate foundType, String customMessage) throws LJError {
+        vcChecker.throwRefinementError(position, declarationPosition, expectedType, foundType, null, customMessage);
     }
 
-    public void throwStateRefinementError(SourcePosition position, Predicate found, Predicate expected,
-            String customMessage) throws LJError {
-        vcChecker.throwStateRefinementError(position, found, expected, customMessage);
+    public void throwStateRefinementError(SourcePosition position, SourcePosition declarationPosition, Predicate found,
+            Predicate expected, String customMessage) throws LJError {
+        vcChecker.throwStateRefinementError(position, declarationPosition, found, expected, customMessage);
     }
 
     public void throwStateConflictError(SourcePosition position, Predicate expectedType) throws LJError {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -38,13 +38,8 @@ public class VCChecker {
         pathVariables = new Stack<>();
     }
 
-    public void processSubtyping(Predicate expectedType, List<GhostState> list, CtElement element, Factory f)
-            throws LJError {
-        processSubtyping(expectedType, list, element, f, null);
-    }
-
     public void processSubtyping(Predicate expectedType, List<GhostState> list, CtElement element, Factory f,
-            String customMessage) throws LJError {
+            SourcePosition declarationPosition, String customMessage) throws LJError {
         List<RefinedVariable> lrv = new ArrayList<>(), mainVars = new ArrayList<>();
         gatherVariables(expectedType, lrv, mainVars);
         if (expectedType.isBooleanTrue())
@@ -82,8 +77,8 @@ public class VCChecker {
         }
         DebugLog.smtResult(result);
         if (result.isError()) {
-            throw new RefinementError(element.getPosition(), expectedType, implBeforeChange.simplify(), map,
-                    result.getCounterexample(), customMessage);
+            throw new RefinementError(element.getPosition(), declarationPosition, expectedType,
+                    implBeforeChange.simplify(), map, result.getCounterexample(), customMessage);
         }
     }
 
@@ -99,10 +94,11 @@ public class VCChecker {
      * @throws LJError
      */
     public void processSubtyping(Predicate type, Predicate expectedType, List<GhostState> list, CtElement element,
-            Factory f) throws LJError {
+            SourcePosition declarationPosition, Factory f) throws LJError {
         SMTResult result = verifySMTSubtypeStates(type, expectedType, list, element.getPosition(), f);
         if (result.isError())
-            throwRefinementError(element.getPosition(), expectedType, type, result.getCounterexample(), null);
+            throwRefinementError(element.getPosition(), declarationPosition, expectedType, type,
+                    result.getCounterexample(), null);
     }
 
     /**
@@ -403,18 +399,20 @@ public class VCChecker {
         return joinPredicates(predicates[0], mainVars, lrv, map);
     }
 
-    protected void throwRefinementError(SourcePosition position, Predicate expected, Predicate found,
-            Counterexample counterexample, String customMessage) throws RefinementError {
+    protected void throwRefinementError(SourcePosition position, SourcePosition declarationPosition, Predicate expected,
+            Predicate found, Counterexample counterexample, String customMessage) throws RefinementError {
         TranslationTable map = new TranslationTable();
         VCImplication premises = buildPremiseChain(map, expected, found);
-        throw new RefinementError(position, expected, premises.simplify(), map, counterexample, customMessage);
+        throw new RefinementError(position, declarationPosition, expected, premises.simplify(), map, counterexample,
+                customMessage);
     }
 
-    protected void throwStateRefinementError(SourcePosition position, Predicate found, Predicate expected,
-            String customMessage) throws StateRefinementError {
+    protected void throwStateRefinementError(SourcePosition position, SourcePosition declarationPosition,
+            Predicate found, Predicate expected, String customMessage) throws StateRefinementError {
         TranslationTable map = new TranslationTable();
         VCImplication foundState = buildPremiseChain(map, expected, found);
-        throw new StateRefinementError(position, expected, foundState.simplify(), map, customMessage);
+        throw new StateRefinementError(position, declarationPosition, expected, foundState.simplify(), map,
+                customMessage);
     }
 
     protected void throwStateConflictError(SourcePosition position, Predicate expected) throws StateConflictError {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
@@ -220,7 +220,7 @@ public class MethodsFunctionsChecker {
                 .substituteVariable(Keys.THIS, returnVarName);
 
         rtc.getContext().addVarToContext(returnVarName, method.getType(), cretRef, ret);
-        rtc.checkSMT(cexpectedType, ret, fi.getMessage());
+        rtc.checkSMT(cexpectedType, ret, fi.getPlacementInCode().getPosition(), fi.getMessage());
         rtc.getContext().newRefinementToVariableInContext(returnVarName, cexpectedType);
 
     }
@@ -426,7 +426,7 @@ public class MethodsFunctionsChecker {
                 VariableInstance vi = (VariableInstance) invocation.getMetadata(Keys.TARGET);
                 c = c.substituteVariable(Keys.THIS, vi.getName());
             }
-            rtc.checkSMT(c, invocation, fArg.getMessage());
+            rtc.checkSMT(c, invocation, fArg.getPlacementInCode().getPosition(), fArg.getMessage());
         }
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxHierarchyRefinementsPassage.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxHierarchyRefinementsPassage.java
@@ -83,7 +83,8 @@ public class AuxHierarchyRefinementsPassage {
             } else {
                 boolean ok = tc.checkStateSMT(superArgRef, argRef, params.get(i).getPosition());
                 if (!ok) {
-                    tc.throwRefinementError(method.getPosition(), argRef, superArgRef, function.getMessage());
+                    tc.throwRefinementError(method.getPosition(), function.getPlacementInCode().getPosition(), argRef,
+                            superArgRef, function.getMessage());
                 }
             }
         }
@@ -107,7 +108,7 @@ public class AuxHierarchyRefinementsPassage {
             for (String m : super2function.keySet())
                 functionRef = functionRef.substituteVariable(m, super2function.get(m));
 
-            tc.checkStateSMT(functionRef, superRef, method,
+            tc.checkStateSMT(functionRef, superRef, method, function.getPlacementInCode().getPosition(),
                     "Return of subclass must be subtype of the return of the superclass");
         }
     }
@@ -143,13 +144,13 @@ public class AuxHierarchyRefinementsPassage {
                     Predicate subConst = matchVariableNames(thisName, superFunction, subFunction, subState.getFrom());
 
                     // fromSup <: fromSub <==> fromSup is sub type and fromSub is expectedType
-                    tc.checkStateSMT(superConst, subConst, method,
+                    tc.checkStateSMT(superConst, subConst, method, subFunction.getPlacementInCode().getPosition(),
                             "FROM State from Superclass must be subtype of FROM State from Subclass");
 
                     superConst = matchVariableNames(thisName, superState.getTo());
                     subConst = matchVariableNames(thisName, superFunction, subFunction, subState.getTo());
                     // toSub <: toSup <==> ToSub is sub type and toSup is expectedType
-                    tc.checkStateSMT(subConst, superConst, method,
+                    tc.checkStateSMT(subConst, superConst, method, superFunction.getPlacementInCode().getPosition(),
                             "TO State from Subclass must be subtype of TO State from Superclass");
 
                 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
@@ -373,7 +373,7 @@ public class AuxStateHandler {
         VariableInstance target = getTarget(invocation);
         if (target != null) {
             if (f.hasStateChange() && !f.getFromStates().isEmpty()) {
-                changeState(tc, target, f.getAllStates(), parentTargetName, map, invocation);
+                changeState(tc, target, f, parentTargetName, map, invocation);
             }
             if (!f.hasStateChange()) {
                 sameState(tc, target, parentTargetName, invocation);
@@ -428,7 +428,8 @@ public class AuxStateHandler {
                 .changeOldMentions(vi.getName(), instanceName);
 
         if (!tc.checkStateSMT(prevState, expectState, fw.getPosition())) { // Invalid field transition
-            tc.throwStateRefinementError(fw.getPosition(), prevState, expectState, stateChange.getMessage());
+            tc.throwStateRefinementError(fw.getPosition(), field.getDeclaringType().getPosition(), prevState,
+                    expectState, stateChange.getMessage());
             return;
         }
 
@@ -451,7 +452,7 @@ public class AuxStateHandler {
         // is a subtype of the variable's main refinement
         if (rv instanceof Variable) {
             Predicate superC = rv.getMainRefinement().substituteVariable(rv.getName(), vi2.getName());
-            tc.checkSMT(superC, fw);
+            tc.checkSMT(superC, fw, rv.getPlacementInCode().getPosition(), null);
             tc.getContext().addRefinementInstanceToVariable(parentTargetName, newInstanceName);
         }
     }
@@ -466,11 +467,12 @@ public class AuxStateHandler {
      * @param map
      * @param invocation
      */
-    private static void changeState(TypeChecker tc, VariableInstance vi, List<ObjectState> stateChanges, String name,
+    private static void changeState(TypeChecker tc, VariableInstance vi, RefinedFunction function, String name,
             Map<String, String> map, CtElement invocation) throws LJError {
         if (vi.getRefinement() == null) {
             return;
         }
+        List<ObjectState> stateChanges = function.getAllStates();
         String instanceName = vi.getName();
         Predicate prevState = vi.getRefinement().substituteVariable(Keys.WILDCARD, instanceName)
                 .substituteVariable(name, instanceName);
@@ -520,7 +522,8 @@ public class AuxStateHandler {
             // combine messages of all state changes
             String message = stateChanges.stream().map(ObjectState::getMessage)
                     .filter(msg -> msg != null && !msg.isBlank()).distinct().collect(Collectors.joining("\n"));
-            tc.throwStateRefinementError(invocation.getPosition(), prevState, expectedStatesDisjunction, message);
+            tc.throwStateRefinementError(invocation.getPosition(), function.getPlacementInCode().getPosition(),
+                    prevState, expectedStatesDisjunction, message);
         }
     }
 
@@ -575,7 +578,7 @@ public class AuxStateHandler {
             // is a subtype of the variable's main refinement
             if (rv instanceof Variable) {
                 Predicate superC = rv.getMainRefinement().substituteVariable(rv.getName(), vi2.getName());
-                tc.checkSMT(superC, invocation);
+                tc.checkSMT(superC, invocation, rv.getPlacementInCode().getPosition(), null);
                 tc.getContext().addRefinementInstanceToVariable(superName, name2);
             }
         }


### PR DESCRIPTION
## Description
This PR adds refinement declaration locations to refinement and state refinement errors.
This is also used by the VS Code extension for typestate errors to get the file that contains the state refinements and generate the state machine diagram for each one.

## Example

### Command-Line Interface

<img width="897" height="227" alt="image" src="https://github.com/user-attachments/assets/983fa49d-892b-41a2-9273-60868812b1aa" />

### VS Code

<img width="419" height="416" alt="image" src="https://github.com/user-attachments/assets/58f6767a-ae00-4c57-9c99-fa226ea3a5af" />


## Related Issue
None.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed