### PR TITLE
Fix Refinement Declaration Positions

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
@@ -103,8 +103,8 @@ public class LJDiagnostic extends RuntimeException {
             if (declarationSnippet != null)
                 sb.append(declarationSnippet);
 
-            sb.append(declPos.getFile().getPath()).append(":").append(declPos.getLine()).append(Colors.RESET)
-                    .append("\n");
+            sb.append("\n").append(declPos.getFile().getPath()).append(":").append(declPos.getLine())
+                    .append(Colors.RESET).append("\n");
         }
 
         return sb.toString();

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
@@ -99,7 +99,7 @@ public class LJDiagnostic extends RuntimeException {
         SourcePosition declPos = getDeclarationPosition();
         if (declPos != null && declPos.getFile() != null && !declPos.equals(position)) {
             sb.append(Colors.CYAN).append("\n--> Refinement declared here:\n").append(Colors.RESET);
-            String declarationSnippet = getSnippet(declPos, 1, 0, Colors.CYAN, null, true);
+            String declarationSnippet = getSnippet(declPos, 1, 1, Colors.CYAN, null, true);
             if (declarationSnippet != null)
                 sb.append(declarationSnippet);
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/ObjectState.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/ObjectState.java
@@ -1,11 +1,14 @@
 package liquidjava.processor.context;
 
 import liquidjava.rj_language.Predicate;
+import spoon.reflect.cu.SourcePosition;
 
 public class ObjectState {
 
     Predicate from;
     Predicate to;
+    SourcePosition fromPosition;
+    SourcePosition toPosition;
     String message;
 
     public ObjectState() {
@@ -28,6 +31,22 @@ public class ObjectState {
 
     public void setTo(Predicate to) {
         this.to = to;
+    }
+
+    public SourcePosition getFromPosition() {
+        return fromPosition;
+    }
+
+    public void setFromPosition(SourcePosition fromPosition) {
+        this.fromPosition = fromPosition;
+    }
+
+    public SourcePosition getToPosition() {
+        return toPosition;
+    }
+
+    public void setToPosition(SourcePosition toPosition) {
+        this.toPosition = toPosition;
     }
 
     public boolean hasFrom() {
@@ -57,7 +76,10 @@ public class ObjectState {
     public ObjectState clone() {
         Predicate clonedFrom = from == null ? null : from.clone();
         Predicate clonedTo = to == null ? null : to.clone();
-        return new ObjectState(clonedFrom, clonedTo, message);
+        ObjectState clone = new ObjectState(clonedFrom, clonedTo, message);
+        clone.setFromPosition(fromPosition);
+        clone.setToPosition(toPosition);
+        return clone;
     }
 
     @Override

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/PlacementInCode.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/PlacementInCode.java
@@ -2,7 +2,7 @@ package liquidjava.processor.context;
 
 import java.lang.annotation.Annotation;
 
-import liquidjava.utils.Utils;
+import liquidjava.utils.constants.Keys;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
@@ -46,7 +46,8 @@ public class PlacementInCode {
             }
         }
         String elemText = elemCopy.toString();
-        SourcePosition annotationPosition = Utils.getFirstLJAnnotationPosition(elem);
+        SourcePosition annotationPosition = elem.getMetadata(Keys.REFINEMENT_POSITION)instanceof SourcePosition p ? p
+                : elem.getPosition();
         return new PlacementInCode(elemText, elem.getPosition(), annotationPosition);
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
@@ -92,6 +92,7 @@ public abstract class TypeChecker extends CtScanner {
             if (an.contentEquals("liquidjava.specification.Refinement")) {
                 String value = getStringFromAnnotation(ann.getValue("value"));
                 ref = Optional.of(value);
+                element.putMetadata(Keys.REFINEMENT_POSITION, Utils.getLJAnnotationPosition(element, value));
 
             } else if (an.contentEquals("liquidjava.specification.RefinementPredicate")) {
                 CtExpression<String> rawValue = ann.getValue("value");
@@ -339,6 +340,8 @@ public abstract class TypeChecker extends CtScanner {
     public void checkVariableRefinements(Predicate refinementFound, String simpleName, CtTypeReference<?> type,
             CtElement usage, CtElement variable) throws LJError {
         Optional<Predicate> expectedType = getRefinementFromAnnotation(variable);
+        SourcePosition declarationPosition = variable.getMetadata(Keys.REFINEMENT_POSITION)instanceof SourcePosition p
+                ? p : variable.getPosition();
         Predicate cEt;
         RefinedVariable mainRV = null;
         if (context.hasVariable(simpleName))
@@ -364,7 +367,7 @@ public abstract class TypeChecker extends CtScanner {
             rv.addSuperType(t);
         context.addRefinementInstanceToVariable(simpleName, newName);
         String customMessage = getMessageFromAnnotation(variable).orElse(mainRV != null ? mainRV.getMessage() : null);
-        checkSMT(cEt, usage, variable.getPosition(), customMessage); // TODO CHANGE
+        checkSMT(cEt, usage, declarationPosition, customMessage);
         context.addRefinementToVariableInContext(simpleName, type, cet, usage);
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
@@ -7,14 +7,18 @@ import java.util.Map;
 import java.util.Optional;
 
 import liquidjava.diagnostics.errors.LJError;
-import liquidjava.processor.context.*;
+import liquidjava.processor.context.Refined;
+import liquidjava.processor.context.RefinedFunction;
+import liquidjava.processor.context.RefinedVariable;
+import liquidjava.processor.context.Variable;
+import liquidjava.processor.context.VariableInstance;
 import liquidjava.processor.refinement_checker.TypeChecker;
-import liquidjava.utils.constants.Formats;
-import liquidjava.utils.constants.Keys;
 import liquidjava.processor.refinement_checker.object_checkers.AuxHierarchyRefinementsPassage;
 import liquidjava.processor.refinement_checker.object_checkers.AuxStateHandler;
 import liquidjava.rj_language.Predicate;
 import liquidjava.utils.Utils;
+import liquidjava.utils.constants.Formats;
+import liquidjava.utils.constants.Keys;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
@@ -120,12 +124,12 @@ public class MethodsFunctionsChecker {
         f.setName(name.replaceAll("\\p{C}", "")); // remove any empty chars from string
         f.setType(method.getType());
         f.setRefReturn(new Predicate());
-        f.setPlacementInCode(method);
         if (className != null)
             f.setClass(className);
         f.setSignature(signature);
         rtc.getContext().addFunctionToContext(f);
         auxGetMethodRefinements(method, f);
+        f.setPlacementInCode(method);
         return f;
     }
 
@@ -220,7 +224,7 @@ public class MethodsFunctionsChecker {
                 .substituteVariable(Keys.THIS, returnVarName);
 
         rtc.getContext().addVarToContext(returnVarName, method.getType(), cretRef, ret);
-        rtc.checkSMT(cexpectedType, ret, fi.getPlacementInCode().getPosition(), fi.getMessage());
+        rtc.checkSMT(cexpectedType, ret, fi.getPlacementInCode().getAnnotationPosition(), fi.getMessage());
         rtc.getContext().newRefinementToVariableInContext(returnVarName, cexpectedType);
 
     }
@@ -426,7 +430,7 @@ public class MethodsFunctionsChecker {
                 VariableInstance vi = (VariableInstance) invocation.getMetadata(Keys.TARGET);
                 c = c.substituteVariable(Keys.THIS, vi.getName());
             }
-            rtc.checkSMT(c, invocation, fArg.getPlacementInCode().getPosition(), fArg.getMessage());
+            rtc.checkSMT(c, invocation, fArg.getPlacementInCode().getAnnotationPosition(), fArg.getMessage());
         }
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxHierarchyRefinementsPassage.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxHierarchyRefinementsPassage.java
@@ -14,6 +14,7 @@ import liquidjava.rj_language.Predicate;
 import liquidjava.utils.Utils;
 import liquidjava.utils.constants.Formats;
 import liquidjava.utils.constants.Keys;
+import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
@@ -83,8 +84,8 @@ public class AuxHierarchyRefinementsPassage {
             } else {
                 boolean ok = tc.checkStateSMT(superArgRef, argRef, params.get(i).getPosition());
                 if (!ok) {
-                    tc.throwRefinementError(method.getPosition(), function.getPlacementInCode().getPosition(), argRef,
-                            superArgRef, function.getMessage());
+                    tc.throwRefinementError(method.getPosition(), arg.getPlacementInCode().getAnnotationPosition(),
+                            argRef, superArgRef, function.getMessage());
                 }
             }
         }
@@ -108,7 +109,7 @@ public class AuxHierarchyRefinementsPassage {
             for (String m : super2function.keySet())
                 functionRef = functionRef.substituteVariable(m, super2function.get(m));
 
-            tc.checkStateSMT(functionRef, superRef, method, function.getPlacementInCode().getPosition(),
+            tc.checkStateSMT(functionRef, superRef, method, function.getPlacementInCode().getAnnotationPosition(),
                     "Return of subclass must be subtype of the return of the superclass");
         }
     }
@@ -144,13 +145,17 @@ public class AuxHierarchyRefinementsPassage {
                     Predicate subConst = matchVariableNames(thisName, superFunction, subFunction, subState.getFrom());
 
                     // fromSup <: fromSub <==> fromSup is sub type and fromSub is expectedType
-                    tc.checkStateSMT(superConst, subConst, method, subFunction.getPlacementInCode().getPosition(),
+                    SourcePosition subFromPosition = subState.getFromPosition() != null ? subState.getFromPosition()
+                            : subFunction.getPlacementInCode().getPosition();
+                    tc.checkStateSMT(superConst, subConst, method, subFromPosition,
                             "FROM State from Superclass must be subtype of FROM State from Subclass");
 
                     superConst = matchVariableNames(thisName, superState.getTo());
                     subConst = matchVariableNames(thisName, superFunction, subFunction, subState.getTo());
                     // toSub <: toSup <==> ToSub is sub type and toSup is expectedType
-                    tc.checkStateSMT(subConst, superConst, method, superFunction.getPlacementInCode().getPosition(),
+                    SourcePosition superToPosition = superState.getToPosition() != null ? superState.getToPosition()
+                            : superFunction.getPlacementInCode().getPosition();
+                    tc.checkStateSMT(subConst, superConst, method, superToPosition,
                             "TO State from Subclass must be subtype of TO State from Superclass");
 
                 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
@@ -74,6 +74,7 @@ public class AuxStateHandler {
                             "State refinement transition must be a boolean expression", to);
                 }
                 state.setTo(p);
+                state.setToPosition(Utils.getLJAnnotationPosition(element, to));
             }
             l.add(state);
         }
@@ -178,12 +179,16 @@ public class AuxStateHandler {
             state.setMessage(msg);
 
         // has from
-        if (from != null)
+        if (from != null) {
             state.setFrom(createStatePredicate(from, f.getTargetClass(), tc, e, false, prefix));
+            state.setFromPosition(Utils.getLJAnnotationPosition(e, from));
+        }
 
         // has to
-        if (to != null)
+        if (to != null) {
             state.setTo(createStatePredicate(to, f.getTargetClass(), tc, e, true, prefix));
+            state.setToPosition(Utils.getLJAnnotationPosition(e, to));
+        }
 
         // has to but not from, state enters with true
         if (from == null && to != null)
@@ -452,7 +457,7 @@ public class AuxStateHandler {
         // is a subtype of the variable's main refinement
         if (rv instanceof Variable) {
             Predicate superC = rv.getMainRefinement().substituteVariable(rv.getName(), vi2.getName());
-            tc.checkSMT(superC, fw, rv.getPlacementInCode().getPosition(), null);
+            tc.checkSMT(superC, fw, rv.getPlacementInCode().getAnnotationPosition(), null);
             tc.getContext().addRefinementInstanceToVariable(parentTargetName, newInstanceName);
         }
     }
@@ -522,8 +527,11 @@ public class AuxStateHandler {
             // combine messages of all state changes
             String message = stateChanges.stream().map(ObjectState::getMessage)
                     .filter(msg -> msg != null && !msg.isBlank()).distinct().collect(Collectors.joining("\n"));
-            tc.throwStateRefinementError(invocation.getPosition(), function.getPlacementInCode().getPosition(),
-                    prevState, expectedStatesDisjunction, message);
+            SourcePosition declarationPosition = stateChanges.stream().filter(ObjectState::hasFrom)
+                    .map(ObjectState::getFromPosition).filter(Objects::nonNull).findFirst()
+                    .orElse(function.getPlacementInCode().getPosition());
+            tc.throwStateRefinementError(invocation.getPosition(), declarationPosition, prevState,
+                    expectedStatesDisjunction, message);
         }
     }
 
@@ -578,7 +586,7 @@ public class AuxStateHandler {
             // is a subtype of the variable's main refinement
             if (rv instanceof Variable) {
                 Predicate superC = rv.getMainRefinement().substituteVariable(rv.getName(), vi2.getName());
-                tc.checkSMT(superC, invocation, rv.getPlacementInCode().getPosition(), null);
+                tc.checkSMT(superC, invocation, rv.getPlacementInCode().getAnnotationPosition(), null);
                 tc.getContext().addRefinementInstanceToVariable(superName, name2);
             }
         }

--- a/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
@@ -20,6 +20,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.reflect.cu.position.SourcePositionImpl;
 
 public class Utils {
 
@@ -60,11 +61,13 @@ public class Utils {
     // Get the position of the annotation with the given value
     public static SourcePosition getLJAnnotationPosition(CtElement element, String value) {
         String quotedValue = "\"" + value + "\"";
-        return getLiquidJavaAnnotations(element)
-                .flatMap(annotation -> getLJAnnotationValues(annotation)
-                        .filter(expr -> quotedValue.equals(expr.toString()))
-                        .map(expr -> expr.getPosition() != null ? expr.getPosition() : annotation.getPosition()))
-                .findFirst().orElse(element.getPosition());
+        return getLiquidJavaAnnotations(element).flatMap(annotation -> getLJAnnotationValues(annotation)
+                .filter(expr -> quotedValue.equals(expr.toString())).map(expr -> {
+                    SourcePosition position = expr.getPosition();
+                    return (SourcePosition) new SourcePositionImpl(position.getCompilationUnit(),
+                            position.getSourceStart() + 1, position.getSourceEnd() - 1,
+                            position.getCompilationUnit().getLineSeparatorPositions());
+                })).findFirst().orElse(element.getPosition());
     }
 
     // Get the position of the first value of the first LJ annotation on the element

--- a/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
@@ -67,12 +67,6 @@ public class Utils {
                 .findFirst().orElse(element.getPosition());
     }
 
-    // Get the position of the first LJ annotation on the element
-    public static SourcePosition getFirstLJAnnotationPosition(CtElement element) {
-        return getLiquidJavaAnnotations(element).map(CtAnnotation::getPosition).filter(pos -> pos != null).findFirst()
-                .orElse(element.getPosition());
-    }
-
     // Get the position of the first value of the first LJ annotation on the element
     public static SourcePosition getFirstLJAnnotationValuePosition(CtElement element) {
         return getLiquidJavaAnnotations(element)

--- a/liquidjava-verifier/src/main/java/liquidjava/utils/constants/Keys.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/utils/constants/Keys.java
@@ -2,6 +2,7 @@ package liquidjava.utils.constants;
 
 public final class Keys {
     public static final String REFINEMENT = "refinement";
+    public static final String REFINEMENT_POSITION = "refinement_position";
     public static final String REFINEMENT_SAT_CHECK = "refinement_sat_check";
     public static final String TARGET = "target";
     public static final String RETURN_VAR_NAME = "return_var_name";


### PR DESCRIPTION
## Description
This PR fixes the declaration positions of refinement and state refinement errors to target the exact refinement location instead of the target element. Follow-up of #285.

## Example

### Before

<img width="835" height="235" alt="image" src="https://github.com/user-attachments/assets/a9ca0955-b2de-4a55-8516-6b70ef03ad96" />

### After

<img width="832" height="261" alt="image" src="https://github.com/user-attachments/assets/e1e31d3f-d36a-4a01-8275-81ef53fa93e5" />


## Related Issue
None.

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist
- [ ] Added/updated tests
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed
