### PR TITLE
Add Hints for Unconstrained Refinements

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/ErrorUnconstrainedRefinement.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorUnconstrainedRefinement.java
@@ -1,0 +1,12 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+
+public class ErrorUnconstrainedRefinement {
+
+    private static void requirePositive(@Refinement("_ > 0") int value) {}
+
+    public static void check(int value) {
+        requirePositive(value); // Refinement Error
+    }
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorUnconstrainedStateRefinement.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorUnconstrainedStateRefinement.java
@@ -1,0 +1,15 @@
+package testSuite;
+
+import liquidjava.specification.Ghost;
+import liquidjava.specification.StateRefinement;
+
+@Ghost("boolean ready")
+public class ErrorUnconstrainedStateRefinement {
+
+    @StateRefinement(from = "ready(this)")
+    public void run() {}
+
+    public static void check(ErrorUnconstrainedStateRefinement value) {
+        value.run(); // State Refinement Error
+    }
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/LJDiagnostic.java
@@ -16,6 +16,7 @@ public class LJDiagnostic extends RuntimeException {
     private String file;
     private SourcePosition position;
     private String hint;
+    private String counterexample;
     private static final String PIPE = " | ";
 
     public LJDiagnostic(String title, String message, SourcePosition pos, String accentColor, String customMessage) {
@@ -41,6 +42,10 @@ public class LJDiagnostic extends RuntimeException {
 
     public String getHint() {
         return hint;
+    }
+
+    public String getCounterexampleStr() {
+        return counterexample;
     }
 
     public SourcePosition getPosition() {
@@ -70,6 +75,10 @@ public class LJDiagnostic extends RuntimeException {
         this.hint = hint;
     }
 
+    public void setCounterexampleStr(String counterexample) {
+        this.counterexample = counterexample;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -82,6 +91,12 @@ public class LJDiagnostic extends RuntimeException {
         String snippet = getSnippet();
         if (snippet != null) {
             sb.append(snippet);
+        }
+
+        // counterexample
+        String counterexample = getCounterexampleStr();
+        if (counterexample != null && !counterexample.isBlank()) {
+            sb.append(" --> ").append(String.join("\n     ", counterexample.split("\n"))).append("\n");
         }
 
         // hint

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/RefinementError.java
@@ -13,6 +13,8 @@ import liquidjava.smt.Counterexample;
 import liquidjava.utils.Pair;
 import spoon.reflect.cu.SourcePosition;
 
+import static liquidjava.rj_language.opt.VCSimplificationUtils.isTrue;
+
 /**
  * Error indicating that a refinement constraint either was violated or cannot be proven
  * 
@@ -37,22 +39,19 @@ public class RefinementError extends LJError {
         this.found = found;
         this.counterexample = filterCounterexample(counterexample);
         this.declarationPosition = declarationPosition;
+        if (!this.counterexample.isEmpty()) {
+            String counterexampleString = this.counterexample.assignments().stream()
+                    .map(a -> VariableFormatter.format(a.first()) + " == " + a.second())
+                    .collect(Collectors.joining(" && "));
+            setCounterexampleStr("Counterexample: " + counterexampleString);
+        }
+        if (isTrue(found.getImplication().toPredicate().getExpression()))
+            setHint("Not enough information to prove the expected refinement. Add a refinement or condition to constrain it.");
     }
 
     @Override
     public SourcePosition getDeclarationPosition() {
         return declarationPosition;
-    }
-
-    @Override
-    public String getHint() {
-        if (counterexample.isEmpty())
-            return null;
-
-        String counterexampleString = counterexample.assignments().stream()
-                .map(a -> VariableFormatter.format(a.first()) + " == " + a.second())
-                .collect(Collectors.joining(" && "));
-        return "Counterexample: " + counterexampleString;
     }
 
     public Counterexample getCounterexample() {

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
@@ -1,5 +1,7 @@
 package liquidjava.diagnostics.errors;
 
+import static liquidjava.rj_language.opt.VCSimplificationUtils.isTrue;
+
 import liquidjava.diagnostics.TranslationTable;
 import liquidjava.processor.VCImplication;
 import liquidjava.rj_language.Predicate;
@@ -27,6 +29,8 @@ public class StateRefinementError extends LJError {
         this.declarationPosition = declarationPosition;
         this.expected = expected;
         this.found = found;
+        if (isTrue(found.getImplication().toPredicate().getExpression()))
+            setHint("No initial state is known for the object. Ensure its constructor is called to define it.");
     }
 
     @Override

--- a/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/diagnostics/errors/StateRefinementError.java
@@ -30,7 +30,7 @@ public class StateRefinementError extends LJError {
         this.expected = expected;
         this.found = found;
         if (isTrue(found.getImplication().toPredicate().getExpression()))
-            setHint("No initial state is known for the object. Ensure its constructor is called to define it.");
+            setHint("No state information is known for this object. Make sure its state is initialized and available at this point.");
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR adds a new hint when a  refinement or state refinement cannot be proven because the found predicate is `true`.

## Examples

<img width="889" height="166" alt="image" src="https://github.com/user-attachments/assets/52d012f9-eb7d-42a0-bc93-e94c3239ee17" />

---

<img width="925" height="160" alt="image" src="https://github.com/user-attachments/assets/1db1a686-5e2e-418c-b64d-377b0304c259" />

## Related Issue

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring

## Checklist

- [x] Added/updated tests under `liquidjava-example/src/main/java/testSuite/` (`Correct*` / `Error*`)
- [x] `mvn test` passes locally
- [ ] Updated docs/README if behavior or API changed